### PR TITLE
feat: add article reading progress button

### DIFF
--- a/src/components/layout/HomeShellFrame.astro
+++ b/src/components/layout/HomeShellFrame.astro
@@ -6,6 +6,7 @@ import FloatingActionButton from "../../components/ui/FloatingActionButton.astro
 import { isAlgoliaSiteSearchConfigured } from "../../config/search";
 import {
   AlignLeft,
+  ArrowUp,
   Monitor,
   Moon,
   Search,
@@ -152,7 +153,6 @@ const {
   <div
     class="floating-action-stack"
     aria-label="Page controls"
-    hidden
     data-home-shell-fab
   >
     <FloatingActionButton
@@ -161,6 +161,18 @@ const {
       iconSvg={TableOfContents}
       className="floating-action-button--toc"
     />
+    <FloatingActionButton
+      id="article-progress-fab"
+      label="Back to top"
+      className="floating-action-button--article-progress"
+    >
+      <span class="article-progress-fab-percent" data-article-progress-percent>
+        0%
+      </span>
+      <span class="article-progress-fab-icon" data-article-progress-icon hidden>
+        <Icon svg={ArrowUp} />
+      </span>
+    </FloatingActionButton>
   </div>
 
   {

--- a/src/components/layout/HomeShellScripts.astro
+++ b/src/components/layout/HomeShellScripts.astro
@@ -11,6 +11,7 @@
   import { initHomeShellContentPageEntrance } from "../../scripts/home-shell-content-page-entrance";
   import { initHomeShellRouteTransitionLock } from "../../scripts/home-shell-route-transition-lock";
   import { initHomeShellSearch } from "../../scripts/home-shell-search";
+  import { initHomeShellArticleProgress } from "../../scripts/home-shell-article-progress";
   import { initHomeShellCodeCopy } from "../../scripts/home-shell-code-copy";
   import {
     cleanupHomeShellConstellationBackground,
@@ -34,6 +35,7 @@
     "__homeShellMobileTocCleanup",
     "__homeShellMobileNavCleanup",
     "__homeShellDesktopSignatureNavCleanup",
+    "__homeShellArticleProgressCleanup",
     "__homeShellCodeCopyCleanup",
   ] as const;
 
@@ -77,6 +79,7 @@
     initHomeShellContentPageEntrance();
     initHomeShellRouteTransitionLock();
     initHomeShellSearch();
+    initHomeShellArticleProgress();
     initHomeShellCodeCopy();
     initHomeShellConstellationBackground();
     initHomeShellWalineComments();

--- a/src/scripts/home-shell-article-progress.ts
+++ b/src/scripts/home-shell-article-progress.ts
@@ -1,0 +1,136 @@
+const ARTICLE_PROGRESS_MIN_SCROLL_PX = 24;
+const SCROLL_DIRECTION_DELTA_PX = 4;
+const REDUCED_MOTION_MEDIA_QUERY = "(prefers-reduced-motion: reduce)";
+
+type HomeShellArticleProgressWindow = Window & {
+  __homeShellArticleProgressCleanup?: () => void;
+};
+
+function clampProgress(value: number) {
+  return Math.min(100, Math.max(0, value));
+}
+
+export function initHomeShellArticleProgress() {
+  const browserWindow = window as HomeShellArticleProgressWindow;
+  browserWindow.__homeShellArticleProgressCleanup?.();
+
+  const controller = new AbortController();
+  let animationFrame = 0;
+
+  const cleanup = () => {
+    controller.abort();
+    if (animationFrame) {
+      window.cancelAnimationFrame(animationFrame);
+    }
+  };
+  browserWindow.__homeShellArticleProgressCleanup = cleanup;
+
+  const contentPage = document.querySelector(
+    "[data-home-shell-content-page].content-page--article",
+  );
+  const button = document.getElementById("article-progress-fab");
+  const percent = button?.querySelector("[data-article-progress-percent]");
+  const icon = button?.querySelector("[data-article-progress-icon]");
+  const motionMedia = window.matchMedia(REDUCED_MOTION_MEDIA_QUERY);
+
+  if (
+    !(contentPage instanceof HTMLElement) ||
+    !(button instanceof HTMLButtonElement) ||
+    !(percent instanceof HTMLElement) ||
+    !(icon instanceof HTMLElement)
+  ) {
+    if (button instanceof HTMLElement) {
+      button.hidden = true;
+    }
+    return;
+  }
+
+  let lastScrollY = window.scrollY;
+  let scrollDirection: "down" | "up" = "down";
+
+  const getArticleProgress = () => {
+    const scrollY = window.scrollY;
+    const viewportHeight = window.innerHeight;
+    const pageHeight = document.documentElement.scrollHeight;
+    const maxPageScroll = Math.max(0, pageHeight - viewportHeight);
+
+    if (maxPageScroll <= 0) return 100;
+    if (scrollY + viewportHeight >= pageHeight - 2) return 100;
+
+    const contentRect = contentPage.getBoundingClientRect();
+    const contentTop = scrollY + contentRect.top;
+    const contentEndScrollY =
+      contentTop + contentPage.offsetHeight - viewportHeight;
+    const contentScrollRange = contentEndScrollY - contentTop;
+
+    if (contentScrollRange <= 0) {
+      return clampProgress(Math.round((scrollY / maxPageScroll) * 100));
+    }
+
+    return clampProgress(
+      Math.round(((scrollY - contentTop) / contentScrollRange) * 100),
+    );
+  };
+
+  const setMode = (mode: "progress" | "top") => {
+    const showTopIcon = mode === "top";
+    percent.hidden = showTopIcon;
+    icon.hidden = !showTopIcon;
+    button.dataset.articleProgressMode = mode;
+  };
+
+  const syncProgressButton = () => {
+    animationFrame = 0;
+
+    const scrollY = window.scrollY;
+    const scrollDelta = scrollY - lastScrollY;
+    if (Math.abs(scrollDelta) >= SCROLL_DIRECTION_DELTA_PX) {
+      scrollDirection = scrollDelta > 0 ? "down" : "up";
+      lastScrollY = scrollY;
+    }
+
+    const progress = getArticleProgress();
+    percent.textContent = `${progress}%`;
+
+    const shouldShowButton = scrollY > ARTICLE_PROGRESS_MIN_SCROLL_PX;
+    button.hidden = !shouldShowButton;
+
+    if (!shouldShowButton) {
+      setMode("progress");
+      return;
+    }
+
+    setMode(scrollDirection === "up" ? "top" : "progress");
+    button.setAttribute(
+      "aria-label",
+      scrollDirection === "up"
+        ? "Back to top"
+        : `Reading progress ${progress}%, back to top`,
+    );
+  };
+
+  const scheduleSync = () => {
+    if (animationFrame) return;
+    animationFrame = window.requestAnimationFrame(syncProgressButton);
+  };
+
+  button.addEventListener(
+    "click",
+    () => {
+      window.scrollTo({
+        top: 0,
+        behavior: motionMedia.matches ? "auto" : "smooth",
+      });
+    },
+    { signal: controller.signal },
+  );
+  window.addEventListener("scroll", scheduleSync, {
+    passive: true,
+    signal: controller.signal,
+  });
+  window.addEventListener("resize", scheduleSync, {
+    signal: controller.signal,
+  });
+
+  syncProgressButton();
+}

--- a/src/scripts/home-shell-mobile-toc.ts
+++ b/src/scripts/home-shell-mobile-toc.ts
@@ -29,9 +29,6 @@ export function initHomeShellMobileToc() {
     if (tocButton instanceof HTMLElement) {
       tocButton.hidden = true;
     }
-    if (fabStack instanceof HTMLElement) {
-      fabStack.hidden = true;
-    }
     return;
   }
 
@@ -50,9 +47,6 @@ export function initHomeShellMobileToc() {
     }
 
     tocButton.hidden = isDesktop;
-    if (fabStack instanceof HTMLElement) {
-      fabStack.hidden = isDesktop;
-    }
     tocButton.setAttribute(
       "aria-expanded",
       String(shell.classList.contains("is-mobile-toc-open")),

--- a/src/style/components/ui/floating-action-button.css
+++ b/src/style/components/ui/floating-action-button.css
@@ -29,6 +29,31 @@
   font-weight: 600;
   line-height: 1;
 }
+
+.floating-action-button--article-progress {
+  font-variant-numeric: tabular-nums;
+}
+
+.article-progress-fab-percent {
+  min-width: 2.1rem;
+  font-size: clamp(0.76rem, 0.72rem + 0.14vw, 0.86rem);
+  font-weight: 700;
+  line-height: 1;
+  text-align: center;
+}
+
+.article-progress-fab-icon,
+.article-progress-fab-icon svg {
+  display: inline-flex;
+  width: 1.12rem;
+  height: 1.12rem;
+}
+
+.article-progress-fab-percent[hidden],
+.article-progress-fab-icon[hidden] {
+  display: none !important;
+}
+
 .floating-action-button[hidden] {
   display: none !important;
 }

--- a/src/style/layouts/home-layout.css
+++ b/src/style/layouts/home-layout.css
@@ -666,7 +666,7 @@
 }
 
 @media (min-width: 56.25rem) {
-  .floating-action-stack {
+  .floating-action-button--toc {
     display: none;
   }
 }


### PR DESCRIPTION
Fixes #8

## Summary
- Add an article-only floating reading progress/back-to-top button
- Show reading percentage while scrolling down and an up arrow while scrolling up
- Keep the mobile TOC button independent from the progress control

## Verification
- pnpm run check
- pnpm run build
- Playwright interaction check on /blog/touying-ethan/