### PR TITLE
feat: add back links to nested pages

### DIFF
--- a/src/components/content/ArticleDetailPage.astro
+++ b/src/components/content/ArticleDetailPage.astro
@@ -94,9 +94,18 @@ const articleJsonLdText = JSON.stringify(articleJsonLd).replace(
   /</g,
   "\\u003c",
 );
+const sectionLabels: Record<string, string> = {
+  blog: "Blog",
+  note: "Note",
+  project: "Project",
+};
+const sectionLabel = sectionLabels[section] ?? section;
 ---
 
 <DocumentPageShell
+  backHref={`/${section}/`}
+  backLabel={`Back to ${sectionLabel}`}
+  backAriaLabel={`Back to ${sectionLabel} list`}
   variant="article"
   title={pageTitle}
   description={description || undefined}

--- a/src/components/content/BackLinkCard.astro
+++ b/src/components/content/BackLinkCard.astro
@@ -1,0 +1,20 @@
+---
+import Icon from "../ui/Icon.astro";
+import { ArrowLeft } from "lucide-static";
+import "../../style/components/content/back-link-card.css";
+
+interface Props {
+  ariaLabel?: string;
+  href: string;
+  label: string;
+}
+
+const { ariaLabel, href, label } = Astro.props as Props;
+---
+
+<a class="back-link-card" href={href} aria-label={ariaLabel || label}>
+  <span class="back-link-card-icon" aria-hidden="true">
+    <Icon svg={ArrowLeft} />
+  </span>
+  <span class="back-link-card-text">{label}</span>
+</a>

--- a/src/components/content/SectionArchivePage.astro
+++ b/src/components/content/SectionArchivePage.astro
@@ -22,6 +22,9 @@ interface Props {
   actionHref?: string;
   actionLabel?: string;
   activityEntries?: ArchiveActivityEntry[];
+  backAriaLabel?: string;
+  backHref?: string;
+  backLabel?: string;
   pageLabel: string;
   title?: string;
   description?: string;
@@ -33,6 +36,9 @@ const {
   actionHref,
   actionLabel,
   activityEntries = [],
+  backAriaLabel,
+  backHref,
+  backLabel,
   pageLabel,
   title,
   description,
@@ -42,6 +48,9 @@ const {
 ---
 
 <CollectionPageShell
+  backAriaLabel={backAriaLabel}
+  backHref={backHref}
+  backLabel={backLabel}
   title={title}
   description={description}
   ogTitle={ogTitle}

--- a/src/components/content/SectionListingPage.astro
+++ b/src/components/content/SectionListingPage.astro
@@ -14,6 +14,9 @@ interface SectionCategoryEntry {
 }
 
 interface Props {
+  backAriaLabel?: string;
+  backHref?: string;
+  backLabel?: string;
   categories: SectionCategoryEntry[];
   pageLabel: string;
   title?: string;
@@ -25,6 +28,9 @@ interface Props {
 }
 
 const {
+  backAriaLabel,
+  backHref,
+  backLabel,
   categories,
   pageLabel,
   title,
@@ -40,6 +46,9 @@ const toAnchorId = (value: string) =>
 ---
 
 <CollectionPageShell
+  backAriaLabel={backAriaLabel}
+  backHref={backHref}
+  backLabel={backLabel}
   title={title}
   description={description}
   ogTitle={ogTitle}

--- a/src/components/layout/CollectionPageShell.astro
+++ b/src/components/layout/CollectionPageShell.astro
@@ -9,6 +9,9 @@ interface TocItem {
 }
 
 interface Props {
+  backAriaLabel?: string;
+  backHref?: string;
+  backLabel?: string;
   title?: string;
   description?: string;
   canonicalUrl?: string;
@@ -25,6 +28,9 @@ interface Props {
 }
 
 const {
+  backAriaLabel,
+  backHref,
+  backLabel,
   title,
   description,
   canonicalUrl,
@@ -42,6 +48,9 @@ const {
 ---
 
 <ContentShell
+  backAriaLabel={backAriaLabel}
+  backHref={backHref}
+  backLabel={backLabel}
   variant="default"
   title={title}
   description={description}

--- a/src/components/layout/ContentShell.astro
+++ b/src/components/layout/ContentShell.astro
@@ -1,9 +1,8 @@
 ﻿---
 import FooterMeta from "../common/FooterMeta.astro";
-import Icon from "../ui/Icon.astro";
+import BackLinkCard from "../content/BackLinkCard.astro";
 import Signature from "../home/signature.astro";
 import HomeLayout from "../../layouts/HomeLayout.astro";
-import { ArrowLeft } from "lucide-static";
 
 interface Props {
   backAriaLabel?: string;
@@ -78,16 +77,11 @@ const {
     <div class="content-page-body">
       {
         backHref && backLabel && (
-          <a
-            class="content-back-link"
+          <BackLinkCard
             href={backHref}
-            aria-label={backAriaLabel || backLabel}
-          >
-            <span class="content-back-link-icon" aria-hidden="true">
-              <Icon svg={ArrowLeft} />
-            </span>
-            <span class="content-back-link-text">{backLabel}</span>
-          </a>
+            label={backLabel}
+            ariaLabel={backAriaLabel}
+          />
         )
       }
       <slot />

--- a/src/components/layout/ContentShell.astro
+++ b/src/components/layout/ContentShell.astro
@@ -1,9 +1,14 @@
 ﻿---
 import FooterMeta from "../common/FooterMeta.astro";
+import Icon from "../ui/Icon.astro";
 import Signature from "../home/signature.astro";
 import HomeLayout from "../../layouts/HomeLayout.astro";
+import { ArrowLeft } from "lucide-static";
 
 interface Props {
+  backAriaLabel?: string;
+  backHref?: string;
+  backLabel?: string;
   mainCol2Fr?: string;
   mainCol3Fr?: string;
   variant?: "default" | "article";
@@ -23,6 +28,9 @@ interface Props {
 }
 
 const {
+  backAriaLabel,
+  backHref,
+  backLabel,
   mainCol2Fr = "4fr",
   mainCol3Fr = "1.5fr",
   variant = "default",
@@ -68,6 +76,20 @@ const {
     data-page-entrance="entered"
   >
     <div class="content-page-body">
+      {
+        backHref && backLabel && (
+          <a
+            class="content-back-link"
+            href={backHref}
+            aria-label={backAriaLabel || backLabel}
+          >
+            <span class="content-back-link-icon" aria-hidden="true">
+              <Icon svg={ArrowLeft} />
+            </span>
+            <span class="content-back-link-text">{backLabel}</span>
+          </a>
+        )
+      }
       <slot />
     </div>
   </section>

--- a/src/components/layout/DocumentPageShell.astro
+++ b/src/components/layout/DocumentPageShell.astro
@@ -9,6 +9,9 @@ interface TocItem {
 }
 
 interface Props {
+  backAriaLabel?: string;
+  backHref?: string;
+  backLabel?: string;
   variant?: "default" | "article";
   background?: "home" | "code-rain" | "constellation" | "content";
   title?: string;
@@ -28,6 +31,9 @@ interface Props {
 }
 
 const {
+  backAriaLabel,
+  backHref,
+  backLabel,
   variant = "default",
   background,
   title,
@@ -48,6 +54,9 @@ const {
 ---
 
 <ContentShell
+  backAriaLabel={backAriaLabel}
+  backHref={backHref}
+  backLabel={backLabel}
   variant={variant}
   background={background}
   title={title}

--- a/src/pages/[section]-archive.astro
+++ b/src/pages/[section]-archive.astro
@@ -164,6 +164,9 @@ const seoDescription = `Browse Ethan's ${basePageLabel.toLowerCase()} categories
 ---
 
 <SectionListingPage
+  backHref={`/${section}/`}
+  backLabel={`Back to ${basePageLabel}`}
+  backAriaLabel={`Back to ${basePageLabel} list`}
   categories={categories}
   pageLabel={pageLabel}
   title={seoTitle}

--- a/src/pages/[section]-archive/[archiveSlug].astro
+++ b/src/pages/[section]-archive/[archiveSlug].astro
@@ -179,6 +179,9 @@ const seoDescription = `Browse Ethan's ${sectionLabel.toLowerCase()} posts in ${
 ---
 
 <SectionArchivePage
+  backHref={`/${section}-archive/`}
+  backLabel={`Back to ${sectionLabel} Categories`}
+  backAriaLabel={`Back to ${sectionLabel} category list`}
   pageLabel={pageLabel}
   title={seoTitle}
   description={seoDescription}

--- a/src/style/components/content/back-link-card.css
+++ b/src/style/components/content/back-link-card.css
@@ -14,12 +14,24 @@
   font-size: clamp(0.82rem, 0.78rem + 0.12vw, 0.94rem);
   line-height: 1.3;
   text-decoration: none;
+  text-decoration-line: none;
   transform: translateX(0);
   transition:
     border-color 0.2s ease,
     background-color 0.2s ease,
     color 0.2s ease,
     transform 0.2s ease;
+}
+
+.content-page-body a.back-link-card,
+.content-page-body a.back-link-card:hover,
+.content-page-body a.back-link-card:focus-visible,
+.content-page-body a.back-link-card *,
+.content-page-body a.back-link-card:hover *,
+.content-page-body a.back-link-card:focus-visible * {
+  text-decoration: none;
+  text-decoration-line: none;
+  text-decoration-thickness: 0;
 }
 
 .back-link-card-icon,

--- a/src/style/components/content/back-link-card.css
+++ b/src/style/components/content/back-link-card.css
@@ -1,0 +1,56 @@
+.back-link-card {
+  width: fit-content;
+  max-width: 100%;
+  margin: 0 0 1rem;
+  padding: 0.48rem 0.66rem;
+  border: 1px solid color-mix(in srgb, var(--line) 14%, transparent);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--line) 3.5%, transparent);
+  box-shadow: 0 0.45rem 1.2rem color-mix(in srgb, var(--line) 6%, transparent);
+  display: flex;
+  align-items: center;
+  gap: 0.42rem;
+  color: color-mix(in srgb, var(--line) 76%, transparent);
+  font-size: clamp(0.82rem, 0.78rem + 0.12vw, 0.94rem);
+  line-height: 1.3;
+  text-decoration: none;
+  transform: translateX(0);
+  transition:
+    border-color 0.2s ease,
+    background-color 0.2s ease,
+    color 0.2s ease,
+    transform 0.2s ease;
+}
+
+.back-link-card-icon,
+.back-link-card-icon svg {
+  display: inline-flex;
+  width: 1rem;
+  height: 1rem;
+}
+
+.back-link-card-text {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+@media (hover: hover) {
+  .back-link-card:hover {
+    border-color: color-mix(in srgb, var(--line) 24%, transparent);
+    background: color-mix(in srgb, var(--line) 5.5%, transparent);
+    color: var(--line);
+    transform: translateX(-0.12rem);
+  }
+}
+
+.back-link-card:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--line) 30%, transparent);
+  outline-offset: 0.22rem;
+  border-color: color-mix(in srgb, var(--line) 24%, transparent);
+  color: var(--line);
+  transform: translateX(-0.12rem);
+}
+
+:is(.content-page--listing, .content-page--collection) .back-link-card {
+  margin-bottom: 0;
+}

--- a/src/style/pages/content-page.css
+++ b/src/style/pages/content-page.css
@@ -14,6 +14,53 @@
   align-self: stretch;
 }
 
+.content-back-link {
+  width: fit-content;
+  max-width: 100%;
+  margin: 0 0 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.42rem;
+  color: color-mix(in srgb, var(--line) 72%, transparent);
+  font-size: clamp(0.82rem, 0.78rem + 0.12vw, 0.94rem);
+  line-height: 1.3;
+  text-decoration: none;
+  transform: translateX(0);
+  transition:
+    color 0.2s ease,
+    transform 0.2s ease;
+}
+
+.content-back-link-icon,
+.content-back-link-icon svg {
+  display: inline-flex;
+  width: 1rem;
+  height: 1rem;
+}
+
+.content-back-link-text {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+@media (hover: hover) {
+  .content-back-link:hover {
+    color: var(--line);
+    transform: translateX(-0.12rem);
+  }
+}
+
+.content-back-link:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--line) 30%, transparent);
+  outline-offset: 0.28rem;
+  color: var(--line);
+  transform: translateX(-0.12rem);
+}
+
+:is(.content-page--listing, .content-page--collection) .content-back-link {
+  margin-bottom: 0;
+}
+
 html[data-js="true"]
   .content-page[data-content-entrance-enabled="true"][data-page-entrance="ready"] {
   opacity: 0;

--- a/src/style/pages/content-page.css
+++ b/src/style/pages/content-page.css
@@ -14,53 +14,6 @@
   align-self: stretch;
 }
 
-.content-back-link {
-  width: fit-content;
-  max-width: 100%;
-  margin: 0 0 1rem;
-  display: flex;
-  align-items: center;
-  gap: 0.42rem;
-  color: color-mix(in srgb, var(--line) 72%, transparent);
-  font-size: clamp(0.82rem, 0.78rem + 0.12vw, 0.94rem);
-  line-height: 1.3;
-  text-decoration: none;
-  transform: translateX(0);
-  transition:
-    color 0.2s ease,
-    transform 0.2s ease;
-}
-
-.content-back-link-icon,
-.content-back-link-icon svg {
-  display: inline-flex;
-  width: 1rem;
-  height: 1rem;
-}
-
-.content-back-link-text {
-  min-width: 0;
-  overflow-wrap: anywhere;
-}
-
-@media (hover: hover) {
-  .content-back-link:hover {
-    color: var(--line);
-    transform: translateX(-0.12rem);
-  }
-}
-
-.content-back-link:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--line) 30%, transparent);
-  outline-offset: 0.28rem;
-  color: var(--line);
-  transform: translateX(-0.12rem);
-}
-
-:is(.content-page--listing, .content-page--collection) .content-back-link {
-  margin-bottom: 0;
-}
-
 html[data-js="true"]
   .content-page[data-content-entrance-enabled="true"][data-page-entrance="ready"] {
   opacity: 0;


### PR DESCRIPTION
Fixes #7

## Summary
- Add a reusable `BackLinkCard` component for parent-page navigation
- Render the card on article pages, category overview pages, and nested archive pages
- Use a compact rectangular card style with an arrow icon and section-aware parent links

## Verification
- pnpm run check
- pnpm run build
- Local preview on http://localhost:4321/
- Playwright checks for article, category overview, and nested archive back-card links