### PR TITLE
fix: adapt button colors for different themes

### DIFF
--- a/src/style/components/content/article-detail-page.css
+++ b/src/style/components/content/article-detail-page.css
@@ -114,6 +114,7 @@ html:lang(zh-CN) .content-page--article {
 .article-comments-thread {
   --waline-theme-color: var(--accent);
   --waline-color: var(--line);
+  --waline-black: #111111;
   --waline-light-grey: color-mix(in srgb, var(--line) 56%, transparent);
   --waline-dark-grey: color-mix(in srgb, var(--line) 82%, transparent);
   --waline-bg-color: transparent;
@@ -194,6 +195,10 @@ html:lang(zh-CN) .content-page--article {
   + div
   > p:first-child {
   display: inline;
+}
+
+:root[data-theme="dark"] .article-comments-thread .wl-btn.primary {
+  color: var(--waline-black);
 }
 
 .article-neighbors {

--- a/src/style/components/content/content-prose.css
+++ b/src/style/components/content/content-prose.css
@@ -575,19 +575,20 @@ html.content-image-lightbox-open {
 }
 
 .content-code-copy {
+  --btn-line: #f5f5f5;
   position: absolute;
   top: 0.55rem;
   right: 0.55rem;
   width: 1.7rem;
   height: 1.7rem;
   padding: 0;
-  border: 1px solid color-mix(in srgb, var(--line) 16%, transparent);
+  border: 1px solid color-mix(in srgb, var(--btn-line) 16%, transparent);
   border-radius: 999px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  color: color-mix(in srgb, var(--line) 72%, transparent);
-  background: color-mix(in srgb, var(--line) 4%, transparent);
+  color: color-mix(in srgb, var(--btn-line) 72%, transparent);
+  background: color-mix(in srgb, var(--btn-line) 4%, transparent);
   cursor: pointer;
 }
 
@@ -598,14 +599,14 @@ html.content-image-lightbox-open {
 }
 
 .content-code-copy:focus-visible {
-  outline: 2px solid color-mix(in srgb, var(--line) 28%, transparent);
+  outline: 2px solid color-mix(in srgb, var(--btn-line) 28%, transparent);
   outline-offset: 0.12rem;
 }
 
 @media (hover: hover) {
   .content-code-copy:hover {
-    color: var(--line);
-    background: color-mix(in srgb, var(--line) 7%, transparent);
+    color: var(--btn-line);
+    background: color-mix(in srgb, var(--btn-line) 7%, transparent);
   }
 }
 


### PR DESCRIPTION
Original:

<img width="400"  src="https://github.com/user-attachments/assets/bb4236bc-ac5e-46ff-a8a0-a7355f68e91f" />

<br>

<img width="250" src="https://github.com/user-attachments/assets/1fb6356b-1307-4c7b-bc77-cca8dca32ece" />

Fixed:

<img width="400" src="https://github.com/user-attachments/assets/7ad6c90f-9bec-4dfd-b11d-93801e04894f" />

<br>

<img width="250" src="https://github.com/user-attachments/assets/8fb2772b-303d-490a-b295-1b0e7a50a72d" />
