### PR TITLE
ci(deploy): 部署 workflow 中的非敏感变量从 secrets 改为 vars

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,11 +10,11 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  SSH_USER: ${{ secrets.SSH_USER || 'ubuntu' }}
-  SSH_PORT: ${{ secrets.SSH_PORT || '22' }}
-  DEPLOY_PATH: ${{ secrets.DEPLOY_PATH || '~/Astro-star' }}
-  PM2_APP_NAME: ${{ secrets.PM2_APP_NAME || 'Astro-star' }}
-  APP_PORT: ${{ secrets.APP_PORT || '4321' }}
+  SSH_USER: ${{ vars.SSH_USER || 'ubuntu' }}
+  SSH_PORT: ${{ vars.SSH_PORT || '22' }}
+  DEPLOY_PATH: ${{ vars.DEPLOY_PATH || '~/Astro-star' }}
+  PM2_APP_NAME: ${{ vars.PM2_APP_NAME || 'Astro-star' }}
+  APP_PORT: ${{ vars.APP_PORT || '4321' }}
 
 jobs:
   deploy:


### PR DESCRIPTION
## 概述

- 将 `.github/workflows/deploy.yml` 中五个非敏感部署变量从 `secrets.*` 改为 `vars.*`：`SSH_USER`、`SSH_PORT`、`DEPLOY_PATH`、`PM2_APP_NAME`、`APP_PORT`。
- 兜底默认值（`ubuntu`、`22`、`~/Astro-star`、`Astro-star`、`4321`）保持不变。
- 敏感字段继续放在 secrets：`SSH_HOST`、`SSH_PRIVATE_KEY`、`ACTIONS_PAT`、`ALGOLIA_*`、`PUBLIC_WALINE_SERVER_URL`、`CODETIME_TOKEN`。

## 动机

这五个值都不是凭证。作为 Secrets 时它们在日志里被遮蔽成 `***`，保存后也无法在 Actions UI 中查看，调试部署目标非常痛苦。作为 repository Variables 后，它们在 UI 和 workflow 日志里都以明文可见，同时仍然可以被每个 fork 自行覆盖。

一个在 fork 上观察到的实际症状：当这五个值被设为 Variables，而 workflow 仍然通过 `secrets.*` 读取时，`||` 兜底默默生效，workflow 会用模板默认值而不是真正配置的目标去部署。改成 `vars.*` 之后，配置路径就和这些值本应归属的位置一致了。

## 使用此 workflow 的 fork 迁移指引

合并后，此前把 `SSH_USER` / `SSH_PORT` / `DEPLOY_PATH` / `PM2_APP_NAME` / `APP_PORT` 设为 Secrets 的 fork，需要在以下位置重新建一遍：

`Settings → Secrets and variables → Actions → Variables`

名字保持不变。之后可以删掉同名 Secrets。

## 测试方案

- [ ] 在某个 fork 上把这五个名字定义为 repository Variables。
- [ ] 触发一次部署（push 到部署分支或通过 `workflow_dispatch` 手动跑）。
- [ ] 确认 job 日志里 `env:` 段显示的是配置的明文值（证明读到了 Variables），而不是兜底默认值。
- [ ] 确认服务器上 rsync 目标和 PM2 app 名符合 Variables 设置。