### PR TITLE
ci:SSH_USER等适合作为变量而非secret

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,11 +10,11 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  SSH_USER: ${{ secrets.SSH_USER || 'ubuntu' }}
-  SSH_PORT: ${{ secrets.SSH_PORT || '22' }}
-  DEPLOY_PATH: ${{ secrets.DEPLOY_PATH || '~/Astro-star' }}
-  PM2_APP_NAME: ${{ secrets.PM2_APP_NAME || 'Astro-star' }}
-  APP_PORT: ${{ secrets.APP_PORT || '4321' }}
+  SSH_USER: ${{ vars.SSH_USER || 'ubuntu' }}
+  SSH_PORT: ${{ vars.SSH_PORT || '22' }}
+  DEPLOY_PATH: ${{ vars.DEPLOY_PATH || '~/Astro-star' }}
+  PM2_APP_NAME: ${{ vars.PM2_APP_NAME || 'Astro-star' }}
+  APP_PORT: ${{ vars.APP_PORT || '4321' }}
 
 jobs:
   deploy:


### PR DESCRIPTION
SSH_USER、SSH_PORT、DEPLOY_PATH、PM2_APP_NAME、APP_PORT 都不是凭证。 作为 repository Variables 时它们在 Actions UI 和 workflow 日志里以明文 可见，比作为 Secrets 时被遮蔽成 *** 更容易检视和调整部署目标。
兜底默认值保持不变。

敏感字段（SSH_HOST、SSH_PRIVATE_KEY）继续放在 secrets。

合并后，请在 Settings -> Secrets and variables -> Actions -> Variables 下定义这五个同名变量。