### PR TITLE
chore(deps): 更新依赖安全基线

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,7 @@
 // @ts-check
 import { defineConfig, envField } from "astro/config";
 import mdx from "@astrojs/mdx";
+import { unified } from "@astrojs/markdown-remark";
 import sitemap from "@astrojs/sitemap";
 import node from "@astrojs/node";
 import rehypeKatex from "rehype-katex";
@@ -46,8 +47,14 @@ export default defineConfig({
       },
       defaultColor: false,
     },
-    remarkPlugins: [remarkMath, remarkDirective, remarkContentFormatDirectives],
-    rehypePlugins: [rehypeKatex, rehypeFigureCaptions],
+    processor: unified({
+      remarkPlugins: [
+        remarkMath,
+        remarkDirective,
+        remarkContentFormatDirectives,
+      ],
+      rehypePlugins: [rehypeKatex, rehypeFigureCaptions],
+    }),
   },
   vite: {
     plugins: [mdxVoidHtmlPlugin()],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Astro-star",
   "type": "module",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "packageManager": "pnpm@10.30.3",
   "scripts": {
     "predev": "node --experimental-strip-types scripts/generate-git-timestamps.ts",
@@ -23,29 +23,32 @@
   "pnpm": {
     "onlyBuiltDependencies": [
       "better-sqlite3"
-    ]
+    ],
+    "overrides": {
+      "esbuild": "0.28.1",
+      "volar-service-yaml": "0.0.71"
+    }
   },
   "devDependencies": {
     "better-sqlite3": "^12.6.2",
     "bson": "^7.2.0",
     "prettier": "latest",
     "prettier-plugin-astro": "latest",
-    "tar": "^7.5.11"
+    "tar": "^7.5.16"
   },
   "dependencies": {
-    "@ascorbic/feed-loader": "^2.0.1",
-    "@rowanmanning/feed-parser": "^2.1.2",
-    "@astrojs/check": "^0.9.6",
-    "@astrojs/markdown-remark": "^6.3.10",
-    "@astrojs/mdx": "^4.3.4",
-    "@astrojs/node": "^9.4.3",
-    "@astrojs/rss": "^4.0.14",
-    "@astrojs/sitemap": "^3.6.0",
-    "@waline/client": "^3.13.0",
-    "astro": "^5.16.6",
+    "@astrojs/check": "^0.9.9",
+    "@astrojs/markdown-remark": "^7.2.0",
+    "@astrojs/mdx": "^6.0.3",
+    "@astrojs/node": "^10.1.4",
+    "@astrojs/rss": "^4.0.18",
+    "@astrojs/sitemap": "^3.7.3",
+    "@rowanmanning/feed-parser": "^2.1.3",
+    "@waline/client": "^3.15.2",
+    "astro": "^6.4.8",
     "astro-auto-import": "^0.5.1",
-    "astro-loader-bluesky-posts": "^1.2.3",
-    "astro-loader-github-prs": "^1.3.1",
+    "astro-loader-bluesky-posts": "^1.2.4",
+    "astro-loader-github-prs": "^2.0.0",
     "astro-robots-txt": "^1.0.0",
     "katex": "^0.16.10",
     "lucide-static": "^0.562.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,48 +4,49 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  esbuild: 0.28.1
+  volar-service-yaml: 0.0.71
+
 importers:
   .:
     dependencies:
-      "@ascorbic/feed-loader":
-        specifier: ^2.0.1
-        version: 2.0.1(astro@5.18.0(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2))
       "@astrojs/check":
-        specifier: ^0.9.6
-        version: 0.9.6(prettier-plugin-astro@0.14.1)(prettier@3.8.1)(typescript@5.9.3)
+        specifier: ^0.9.9
+        version: 0.9.9(prettier-plugin-astro@0.14.1)(prettier@3.8.4)(typescript@5.9.3)
       "@astrojs/markdown-remark":
-        specifier: ^6.3.10
-        version: 6.3.10
+        specifier: ^7.2.0
+        version: 7.2.0
       "@astrojs/mdx":
-        specifier: ^4.3.4
-        version: 4.3.13(astro@5.18.0(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2))
+        specifier: ^6.0.3
+        version: 6.0.3(astro@6.4.8(@types/node@24.13.2)(rollup@4.62.0)(yaml@2.9.0))
       "@astrojs/node":
-        specifier: ^9.4.3
-        version: 9.5.5(astro@5.18.0(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2))
+        specifier: ^10.1.4
+        version: 10.1.4(astro@6.4.8(@types/node@24.13.2)(rollup@4.62.0)(yaml@2.9.0))
       "@astrojs/rss":
-        specifier: ^4.0.14
-        version: 4.0.15
+        specifier: ^4.0.18
+        version: 4.0.18
       "@astrojs/sitemap":
-        specifier: ^3.6.0
-        version: 3.7.0
+        specifier: ^3.7.3
+        version: 3.7.3
       "@rowanmanning/feed-parser":
-        specifier: ^2.1.2
-        version: 2.1.2
+        specifier: ^2.1.3
+        version: 2.1.3
       "@waline/client":
-        specifier: ^3.13.0
-        version: 3.13.0(typescript@5.9.3)
+        specifier: ^3.15.2
+        version: 3.15.2(typescript@5.9.3)
       astro:
-        specifier: ^5.16.6
-        version: 5.18.0(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2)
+        specifier: ^6.4.8
+        version: 6.4.8(@types/node@24.13.2)(rollup@4.62.0)(yaml@2.9.0)
       astro-auto-import:
         specifier: ^0.5.1
-        version: 0.5.1(astro@5.18.0(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2))
+        version: 0.5.1(astro@6.4.8(@types/node@24.13.2)(rollup@4.62.0)(yaml@2.9.0))
       astro-loader-bluesky-posts:
-        specifier: ^1.2.3
-        version: 1.2.3(astro@5.18.0(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2))
+        specifier: ^1.2.4
+        version: 1.2.4(astro@6.4.8(@types/node@24.13.2)(rollup@4.62.0)(yaml@2.9.0))
       astro-loader-github-prs:
-        specifier: ^1.3.1
-        version: 1.3.1(astro@5.18.0(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2))
+        specifier: ^2.0.0
+        version: 2.0.0(astro@6.4.8(@types/node@24.13.2)(rollup@4.62.0)(yaml@2.9.0))
       astro-robots-txt:
         specifier: ^1.0.0
         version: 1.0.0
@@ -82,39 +83,23 @@ importers:
         version: 7.2.0
       prettier:
         specifier: latest
-        version: 3.8.1
+        version: 3.8.4
       prettier-plugin-astro:
         specifier: latest
         version: 0.14.1
       tar:
-        specifier: ^7.5.11
-        version: 7.5.11
+        specifier: ^7.5.16
+        version: 7.5.16
 
 packages:
-  "@ascorbic/feed-loader@2.0.1":
+  "@astrojs/check@0.9.9":
     resolution:
       {
-        integrity: sha512-nlP4WTp0Ea6J4q3vOleGK0d0l9s4bvKXTvAkttRgvobGb4AslsWm3LOciObWux9wKmzNjk0xSgJt9s00skXeFw==,
-      }
-    peerDependencies:
-      astro: ^4.14.0 || ^5.0.0
-
-  "@ascorbic/loader-utils@1.0.2":
-    resolution:
-      {
-        integrity: sha512-pg43g83gojVtEsAkXfjWuzJhuXneJp4wM/leBftGkCPV3yxKgB92EWA+nWu735BgbBMph3P7DrVqVc3ikt+dJA==,
-      }
-    peerDependencies:
-      astro: ^4.14.0 || ^5.0.0-beta.0
-
-  "@astrojs/check@0.9.6":
-    resolution:
-      {
-        integrity: sha512-jlaEu5SxvSgmfGIFfNgcn5/f+29H61NJzEMfAZ82Xopr4XBchXB1GVlcJsE+elUlsYSbXlptZLX+JMG3b/wZEA==,
+        integrity: sha512-A5UW8uIuErLWEoRQvzgXpO1gTjUFtK8r7nU2Z7GewAMxUb7bPvpk11qaKKgxqXlHJWlAvaaxy+Xg28A6bmQ1Tg==,
       }
     hasBin: true
     peerDependencies:
-      typescript: ^5.0.0
+      typescript: ^5.0.0 || ^6.0.0
 
   "@astrojs/compiler@2.13.1":
     resolution:
@@ -122,22 +107,22 @@ packages:
         integrity: sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==,
       }
 
-  "@astrojs/internal-helpers@0.7.5":
+  "@astrojs/compiler@4.0.0":
     resolution:
       {
-        integrity: sha512-vreGnYSSKhAjFJCWAwe/CNhONvoc5lokxtRoZims+0wa3KbHBdPHSSthJsKxPd8d/aic6lWKpRTYGY/hsgK6EA==,
+        integrity: sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA==,
       }
 
-  "@astrojs/internal-helpers@0.7.6":
+  "@astrojs/internal-helpers@0.10.0":
     resolution:
       {
-        integrity: sha512-GOle7smBWKfMSP8osUIGOlB5kaHdQLV3foCsf+5Q9Wsuu+C6Fs3Ez/ttXmhjZ1HkSgsogcM1RXSjjOVieHq16Q==,
+        integrity: sha512-Ry2R3VPeIN4uPCSA4xQc+e+vsJXkalKpEbDc07hV+a/o5Bs2N/s/uDcPJH/05L19DKh9tAy7e6JM3YZ6Cxfezw==,
       }
 
-  "@astrojs/language-server@2.16.3":
+  "@astrojs/language-server@2.16.10":
     resolution:
       {
-        integrity: sha512-yO5K7RYCMXUfeDlnU6UnmtnoXzpuQc0yhlaCNZ67k1C/MiwwwvMZz+LGa+H35c49w5QBfvtr4w4Zcf5PcH8uYA==,
+        integrity: sha512-87VQ/5GSdHlRnUA+hGuerYyIGAj+9RbZmATyuKLEUePinUXhQ5YkRnRrHhOD9sSi5JOErLjrLkHnfZFEvGrV8w==,
       }
     hasBin: true
     peerDependencies:
@@ -149,150 +134,163 @@ packages:
       prettier-plugin-astro:
         optional: true
 
-  "@astrojs/markdown-remark@6.3.10":
+  "@astrojs/markdown-remark@7.2.0":
     resolution:
       {
-        integrity: sha512-kk4HeYR6AcnzC4QV8iSlOfh+N8TZ3MEStxPyenyCtemqn8IpEATBFMTJcfrNW32dgpt6MY3oCkMM/Tv3/I4G3A==,
+        integrity: sha512-+YxmVQu1Bd+MFfSzjq1rOJvD9+nIOJzz5YIIhdIH01RrxRkKbyKoEgyIqP3yv51MhzMDgd79QaPv+kCVPT8vHw==,
       }
 
-  "@astrojs/mdx@4.3.13":
+  "@astrojs/mdx@6.0.3":
     resolution:
       {
-        integrity: sha512-IHDHVKz0JfKBy3//52JSiyWv089b7GVSChIXLrlUOoTLWowG3wr2/8hkaEgEyd/vysvNQvGk+QhysXpJW5ve6Q==,
+        integrity: sha512-+4P3ZvwsRAqAbBgY+uZMewFo3ficlIBPZfu/Luk+v4ia/ZOuFhpsw7r+7672uT2Fc1UPdp7yW0eU5egvSq0wbw==,
       }
-    engines: { node: 18.20.8 || ^20.3.0 || >=22.0.0 }
+    engines: { node: ">=22.12.0" }
     peerDependencies:
-      astro: ^5.0.0
+      "@astrojs/markdown-satteri": 0.3.0
+      astro: ^6.4.0
+    peerDependenciesMeta:
+      "@astrojs/markdown-satteri":
+        optional: true
 
-  "@astrojs/node@9.5.5":
+  "@astrojs/node@10.1.4":
     resolution:
       {
-        integrity: sha512-rtU2BGU5u3SfGURpANfMxVzCIoR86MkaN05ncza9rbtuMKJ/XnRJt/BbyVknDbOJ71hoci0SIsJwKcJR8vvi/A==,
+        integrity: sha512-itV568ttlrpwNsutO+KPziqKfzTPlAIXMADlpBi3VeQ3liivRKKKG+jm+IjLMKvYGkxd0QnClKVCBP4i3gpwQQ==,
       }
     peerDependencies:
-      astro: ^5.17.3
+      astro: ^6.3.0
 
-  "@astrojs/prism@3.3.0":
+  "@astrojs/prism@4.0.2":
     resolution:
       {
-        integrity: sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ==,
+        integrity: sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA==,
+      }
+    engines: { node: ">=22.12.0" }
+
+  "@astrojs/rss@4.0.18":
+    resolution:
+      {
+        integrity: sha512-wc5DwKlbTEdgVAWnHy8krFTeQ42t1v/DJqeq5HtulYK3FYHE4krtRGjoyhS3eXXgfdV6Raoz2RU3wrMTFAitRg==,
+      }
+
+  "@astrojs/sitemap@3.7.3":
+    resolution:
+      {
+        integrity: sha512-f8euLVsyeAmAkSm/1M2Kb8sL8byQmfgbvBNaHFItCheTj/IpiJYSEWVcqDHZ/yEHxiS7+w87mQkzwZaPHmk5GA==,
+      }
+
+  "@astrojs/telemetry@3.3.2":
+    resolution:
+      {
+        integrity: sha512-j8DNruA8ors99Al39RYZPJK4DC1bKkoNm93mAMuBhY9TCNC4R8n1q7ovFnJ5qhGh5Lsh7pa1gpQVpYpsJPeTHQ==,
       }
     engines: { node: 18.20.8 || ^20.3.0 || >=22.0.0 }
 
-  "@astrojs/rss@4.0.15":
+  "@astrojs/yaml2ts@0.2.4":
     resolution:
       {
-        integrity: sha512-uXO/k6AhRkIDXmRoc6xQpoPZrimQNUmS43X4+60yunfuMNHtSRN5e/FiSi7NApcZqmugSMc5+cJi8ovqgO+qIg==,
+        integrity: sha512-8oddpOae35pJsXPQXhTkM0ypfKPskVsh2bCxRtbf7e+/Epw2nReakFYpLKjZMEr75CsoF203PMnCocpfz0s69A==,
       }
 
-  "@astrojs/sitemap@3.7.0":
+  "@atproto/api@0.20.16":
     resolution:
       {
-        integrity: sha512-+qxjUrz6Jcgh+D5VE1gKUJTA3pSthuPHe6Ao5JCxok794Lewx8hBFaWHtOnN0ntb2lfOf7gvOi9TefUswQ/ZVA==,
+        integrity: sha512-hKgBgZS9K+ia6AMKo26q75EiDRqvSabpo0SmpeuYRHVGTV+7y35lJVgHtuwGhVXNphyQ0Q9TIg8A5YnRVARXNw==,
       }
+    engines: { node: ">=22" }
 
-  "@astrojs/telemetry@3.3.0":
+  "@atproto/common-web@0.5.1":
     resolution:
       {
-        integrity: sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==,
+        integrity: sha512-nru02gLyzjMQn4ZFgms9ry3kIAKwMaCAvjeFhB9mU6h1ABiSho7aRDbGvnU50CC88TROXuZlgRiEkBjnuiHEtA==,
       }
-    engines: { node: 18.20.8 || ^20.3.0 || >=22.0.0 }
+    engines: { node: ">=22" }
 
-  "@astrojs/yaml2ts@0.2.2":
+  "@atproto/lex-data@0.1.2":
     resolution:
       {
-        integrity: sha512-GOfvSr5Nqy2z5XiwqTouBBpy5FyI6DEe+/g/Mk5am9SjILN1S5fOEvYK0GuWHg98yS/dobP4m8qyqw/URW35fQ==,
+        integrity: sha512-NZ4iZvNaqTM6pz+9VRDyEjtozrrf2EDHySNi3Xa8PCzS8gRMCvsnnsvM7r264v4eSqNIDhBB8fr9hfWCHMspXg==,
       }
+    engines: { node: ">=22" }
 
-  "@atproto/api@0.17.7":
+  "@atproto/lex-json@0.1.1":
     resolution:
       {
-        integrity: sha512-V+OJBZq9chcrD21xk1bUa6oc5DSKfQj5DmUPf5rmZncqL1w9ZEbS38H5cMyqqdhfgo2LWeDRdZHD0rvNyJsIaw==,
+        integrity: sha512-FC/NsKHm8TDzWikvf/268T3mMAh6+f31yfCApWC3SvrhWc9c06cSYPp7qzpXcdV0OdB+I5dqHScuTB5OC7HrXg==,
       }
+    engines: { node: ">=22" }
 
-  "@atproto/common-web@0.4.18":
+  "@atproto/lexicon@0.7.2":
     resolution:
       {
-        integrity: sha512-ilImzP+9N/mtse440kN60pGrEzG7wi4xsV13nGeLrS+Zocybc/ISOpKlbZM13o+twPJ+Q7veGLw9CtGg0GAFoQ==,
+        integrity: sha512-LVZcTr5+9Qh0okZnNmfRiIDPfbL/6rRxf4goiQxPxwDzaeUDhn4M209i1drmiitbCO1qRLJA2hHF54yNA75Cig==,
       }
+    engines: { node: ">=22" }
 
-  "@atproto/lex-data@0.0.13":
+  "@atproto/syntax@0.6.2":
     resolution:
       {
-        integrity: sha512-7Z7RwZ1Y/JzBF/Tcn/I4UJ/vIGfh5zn1zjv0KX+flke2JtgFkSE8uh2hOtqgBQMNqE3zdJFM+dcSWln86hR3MQ==,
+        integrity: sha512-h3njTNFl/jv5kTbDqfamQGOJfGbulqLDuAiLbasKwVdBhFyQanpRLa6vE2WqTwv1XEFWLYNMH0KCVsYwT2+aww==,
       }
+    engines: { node: ">=22" }
 
-  "@atproto/lex-json@0.0.13":
+  "@atproto/xrpc@0.8.1":
     resolution:
       {
-        integrity: sha512-hwLhkKaIHulGJpt0EfXAEWdrxqM2L1tV/tvilzhMp3QxPqYgXchFnrfVmLsyFDx6P6qkH1GsX/XC2V36U0UlPQ==,
+        integrity: sha512-sKopRG3an6LN6NfHnRNIEX1fBx3CRtxbNFWQxyse2f86wMcTuXM+/+olN4lVXgFQgv4AWvKTxRXWyuIF2G4YxQ==,
       }
+    engines: { node: ">=22" }
 
-  "@atproto/lexicon@0.5.2":
+  "@babel/helper-string-parser@7.29.7":
     resolution:
       {
-        integrity: sha512-lRmJgMA8f5j7VB5Iu5cp188ald5FuI4FlmZ7nn6EBrk1dgOstWVrI5Ft6K3z2vjyLZRG6nzknlsw+tDP63p7bQ==,
-      }
-
-  "@atproto/lexicon@0.6.2":
-    resolution:
-      {
-        integrity: sha512-p3Ly6hinVZW0ETuAXZMeUGwuMm3g8HvQMQ41yyEE6AL0hAkfeKFaZKos6BdBrr6CjkpbrDZqE8M+5+QOceysMw==,
-      }
-
-  "@atproto/syntax@0.4.3":
-    resolution:
-      {
-        integrity: sha512-YoZUz40YAJr5nPwvCDWgodEOlt5IftZqPJvA0JDWjuZKD8yXddTwSzXSaKQAzGOpuM+/A3uXRtPzJJqlScc+iA==,
-      }
-
-  "@atproto/syntax@0.5.0":
-    resolution:
-      {
-        integrity: sha512-UA2DSpGdOQzUQ4gi5SH+NEJz/YR3a3Fg3y2oh+xETDSiTRmA4VhHRCojhXAVsBxUT6EnItw190C/KN+DWW90kw==,
-      }
-
-  "@atproto/xrpc@0.7.7":
-    resolution:
-      {
-        integrity: sha512-K1ZyO/BU8JNtXX5dmPp7b5UrkLMMqpsIa/Lrj5D3Su+j1Xwq1m6QJ2XJ1AgjEjkI1v4Muzm7klianLE6XGxtmA==,
-      }
-
-  "@babel/helper-string-parser@7.27.1":
-    resolution:
-      {
-        integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==,
+        integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==,
       }
     engines: { node: ">=6.9.0" }
 
-  "@babel/helper-validator-identifier@7.28.5":
+  "@babel/helper-validator-identifier@7.29.7":
     resolution:
       {
-        integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==,
+        integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==,
       }
     engines: { node: ">=6.9.0" }
 
-  "@babel/parser@7.29.0":
+  "@babel/parser@7.29.7":
     resolution:
       {
-        integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==,
+        integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==,
       }
     engines: { node: ">=6.0.0" }
     hasBin: true
 
-  "@babel/types@7.29.0":
+  "@babel/types@7.29.7":
     resolution:
       {
-        integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==,
+        integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==,
       }
     engines: { node: ">=6.9.0" }
 
-  "@capsizecss/unpack@4.0.0":
+  "@capsizecss/unpack@4.0.1":
     resolution:
       {
-        integrity: sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA==,
+        integrity: sha512-CuNiSqg7+e1cO/GjffyMOm5Tt2jUF9CWHHnvQ/UkqvtkGfHdgwEC0wpmq7fkN3gxwpRnrAN0WzO3vREKmNolMQ==,
       }
     engines: { node: ">=18" }
+
+  "@clack/core@1.4.1":
+    resolution:
+      {
+        integrity: sha512-FILJa1gGKEFTGZAJE9RpVhrjKz3c3h4ar60dSv6cGuDqufQ84YEIS3GAGvZiN+H6yaLbbvTFNejjCC4tXpZEuw==,
+      }
+    engines: { node: ">= 20.12.0" }
+
+  "@clack/prompts@1.5.1":
+    resolution:
+      {
+        integrity: sha512-zccHj2z2oCCO4yrDiRSlFOxWerGqRiysP7a5jPK6uoI9URKAquwY42Dd/iUP8JWHxEzdRe4TlbvZCo8z1/mhrw==,
+      }
+    engines: { node: ">= 20.12.0" }
 
   "@emmetio/abbreviation@2.3.3":
     resolution:
@@ -336,475 +334,241 @@ packages:
         integrity: sha512-fXVXEyFA5Yv3M3n8sUGT7+fvecGrZP4k6FnWWMSZVQf69kAq0LLpaBQLGcPR30m3zMmKYhECP4k/ZkzvhEW5kw==,
       }
 
-  "@emnapi/runtime@1.8.1":
+  "@emnapi/runtime@1.11.1":
     resolution:
       {
-        integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==,
+        integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==,
       }
 
-  "@esbuild/aix-ppc64@0.25.12":
+  "@esbuild/aix-ppc64@0.28.1":
     resolution:
       {
-        integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [ppc64]
-    os: [aix]
-
-  "@esbuild/aix-ppc64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==,
+        integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==,
       }
     engines: { node: ">=18" }
     cpu: [ppc64]
     os: [aix]
 
-  "@esbuild/android-arm64@0.25.12":
+  "@esbuild/android-arm64@0.28.1":
     resolution:
       {
-        integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==,
+        integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
     os: [android]
 
-  "@esbuild/android-arm64@0.27.3":
+  "@esbuild/android-arm@0.28.1":
     resolution:
       {
-        integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [android]
-
-  "@esbuild/android-arm@0.25.12":
-    resolution:
-      {
-        integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==,
+        integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==,
       }
     engines: { node: ">=18" }
     cpu: [arm]
     os: [android]
 
-  "@esbuild/android-arm@0.27.3":
+  "@esbuild/android-x64@0.28.1":
     resolution:
       {
-        integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm]
-    os: [android]
-
-  "@esbuild/android-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==,
+        integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
     os: [android]
 
-  "@esbuild/android-x64@0.27.3":
+  "@esbuild/darwin-arm64@0.28.1":
     resolution:
       {
-        integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
-    os: [android]
-
-  "@esbuild/darwin-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==,
+        integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
     os: [darwin]
 
-  "@esbuild/darwin-arm64@0.27.3":
+  "@esbuild/darwin-x64@0.28.1":
     resolution:
       {
-        integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [darwin]
-
-  "@esbuild/darwin-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==,
+        integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
     os: [darwin]
 
-  "@esbuild/darwin-x64@0.27.3":
+  "@esbuild/freebsd-arm64@0.28.1":
     resolution:
       {
-        integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
-    os: [darwin]
-
-  "@esbuild/freebsd-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==,
+        integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
     os: [freebsd]
 
-  "@esbuild/freebsd-arm64@0.27.3":
+  "@esbuild/freebsd-x64@0.28.1":
     resolution:
       {
-        integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [freebsd]
-
-  "@esbuild/freebsd-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==,
+        integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
     os: [freebsd]
 
-  "@esbuild/freebsd-x64@0.27.3":
+  "@esbuild/linux-arm64@0.28.1":
     resolution:
       {
-        integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
-    os: [freebsd]
-
-  "@esbuild/linux-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==,
+        integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
     os: [linux]
 
-  "@esbuild/linux-arm64@0.27.3":
+  "@esbuild/linux-arm@0.28.1":
     resolution:
       {
-        integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [linux]
-
-  "@esbuild/linux-arm@0.25.12":
-    resolution:
-      {
-        integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==,
+        integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==,
       }
     engines: { node: ">=18" }
     cpu: [arm]
     os: [linux]
 
-  "@esbuild/linux-arm@0.27.3":
+  "@esbuild/linux-ia32@0.28.1":
     resolution:
       {
-        integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm]
-    os: [linux]
-
-  "@esbuild/linux-ia32@0.25.12":
-    resolution:
-      {
-        integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==,
+        integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==,
       }
     engines: { node: ">=18" }
     cpu: [ia32]
     os: [linux]
 
-  "@esbuild/linux-ia32@0.27.3":
+  "@esbuild/linux-loong64@0.28.1":
     resolution:
       {
-        integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==,
-      }
-    engines: { node: ">=18" }
-    cpu: [ia32]
-    os: [linux]
-
-  "@esbuild/linux-loong64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==,
+        integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==,
       }
     engines: { node: ">=18" }
     cpu: [loong64]
     os: [linux]
 
-  "@esbuild/linux-loong64@0.27.3":
+  "@esbuild/linux-mips64el@0.28.1":
     resolution:
       {
-        integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [loong64]
-    os: [linux]
-
-  "@esbuild/linux-mips64el@0.25.12":
-    resolution:
-      {
-        integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==,
+        integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==,
       }
     engines: { node: ">=18" }
     cpu: [mips64el]
     os: [linux]
 
-  "@esbuild/linux-mips64el@0.27.3":
+  "@esbuild/linux-ppc64@0.28.1":
     resolution:
       {
-        integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==,
-      }
-    engines: { node: ">=18" }
-    cpu: [mips64el]
-    os: [linux]
-
-  "@esbuild/linux-ppc64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==,
+        integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==,
       }
     engines: { node: ">=18" }
     cpu: [ppc64]
     os: [linux]
 
-  "@esbuild/linux-ppc64@0.27.3":
+  "@esbuild/linux-riscv64@0.28.1":
     resolution:
       {
-        integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [ppc64]
-    os: [linux]
-
-  "@esbuild/linux-riscv64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==,
+        integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==,
       }
     engines: { node: ">=18" }
     cpu: [riscv64]
     os: [linux]
 
-  "@esbuild/linux-riscv64@0.27.3":
+  "@esbuild/linux-s390x@0.28.1":
     resolution:
       {
-        integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==,
-      }
-    engines: { node: ">=18" }
-    cpu: [riscv64]
-    os: [linux]
-
-  "@esbuild/linux-s390x@0.25.12":
-    resolution:
-      {
-        integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==,
+        integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==,
       }
     engines: { node: ">=18" }
     cpu: [s390x]
     os: [linux]
 
-  "@esbuild/linux-s390x@0.27.3":
+  "@esbuild/linux-x64@0.28.1":
     resolution:
       {
-        integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==,
-      }
-    engines: { node: ">=18" }
-    cpu: [s390x]
-    os: [linux]
-
-  "@esbuild/linux-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==,
+        integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
     os: [linux]
 
-  "@esbuild/linux-x64@0.27.3":
+  "@esbuild/netbsd-arm64@0.28.1":
     resolution:
       {
-        integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
-    os: [linux]
-
-  "@esbuild/netbsd-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==,
+        integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
     os: [netbsd]
 
-  "@esbuild/netbsd-arm64@0.27.3":
+  "@esbuild/netbsd-x64@0.28.1":
     resolution:
       {
-        integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [netbsd]
-
-  "@esbuild/netbsd-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==,
+        integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
     os: [netbsd]
 
-  "@esbuild/netbsd-x64@0.27.3":
+  "@esbuild/openbsd-arm64@0.28.1":
     resolution:
       {
-        integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
-    os: [netbsd]
-
-  "@esbuild/openbsd-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==,
+        integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
     os: [openbsd]
 
-  "@esbuild/openbsd-arm64@0.27.3":
+  "@esbuild/openbsd-x64@0.28.1":
     resolution:
       {
-        integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [openbsd]
-
-  "@esbuild/openbsd-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==,
+        integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
     os: [openbsd]
 
-  "@esbuild/openbsd-x64@0.27.3":
+  "@esbuild/openharmony-arm64@0.28.1":
     resolution:
       {
-        integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
-    os: [openbsd]
-
-  "@esbuild/openharmony-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==,
+        integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
     os: [openharmony]
 
-  "@esbuild/openharmony-arm64@0.27.3":
+  "@esbuild/sunos-x64@0.28.1":
     resolution:
       {
-        integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [openharmony]
-
-  "@esbuild/sunos-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==,
+        integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
     os: [sunos]
 
-  "@esbuild/sunos-x64@0.27.3":
+  "@esbuild/win32-arm64@0.28.1":
     resolution:
       {
-        integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
-    os: [sunos]
-
-  "@esbuild/win32-arm64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==,
+        integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==,
       }
     engines: { node: ">=18" }
     cpu: [arm64]
     os: [win32]
 
-  "@esbuild/win32-arm64@0.27.3":
+  "@esbuild/win32-ia32@0.28.1":
     resolution:
       {
-        integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [arm64]
-    os: [win32]
-
-  "@esbuild/win32-ia32@0.25.12":
-    resolution:
-      {
-        integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==,
+        integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==,
       }
     engines: { node: ">=18" }
     cpu: [ia32]
     os: [win32]
 
-  "@esbuild/win32-ia32@0.27.3":
+  "@esbuild/win32-x64@0.28.1":
     resolution:
       {
-        integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==,
-      }
-    engines: { node: ">=18" }
-    cpu: [ia32]
-    os: [win32]
-
-  "@esbuild/win32-x64@0.25.12":
-    resolution:
-      {
-        integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==,
-      }
-    engines: { node: ">=18" }
-    cpu: [x64]
-    os: [win32]
-
-  "@esbuild/win32-x64@0.27.3":
-    resolution:
-      {
-        integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==,
+        integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
@@ -1057,6 +821,12 @@ packages:
         integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==,
       }
 
+  "@nodable/entities@2.2.0":
+    resolution:
+      {
+        integrity: sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==,
+      }
+
   "@octokit/app@16.1.2":
     resolution:
       {
@@ -1212,10 +982,10 @@ packages:
       }
     engines: { node: ">= 20" }
 
-  "@octokit/request@10.0.8":
+  "@octokit/request@10.0.10":
     resolution:
       {
-        integrity: sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==,
+        integrity: sha512-KxNC2pTqqhszMNrf12ZRd4PonRgyJdsM4F/jySiddQK+DsRcfBtUvqn8t7UsyZhnRJHvX46OohDt5N3VqIWC2w==,
       }
     engines: { node: ">= 20" }
 
@@ -1245,10 +1015,10 @@ packages:
         integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==,
       }
 
-  "@rollup/pluginutils@5.3.0":
+  "@rollup/pluginutils@5.4.0":
     resolution:
       {
-        integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==,
+        integrity: sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==,
       }
     engines: { node: ">=14.0.0" }
     peerDependencies:
@@ -1257,261 +1027,274 @@ packages:
       rollup:
         optional: true
 
-  "@rollup/rollup-android-arm-eabi@4.59.0":
+  "@rollup/rollup-android-arm-eabi@4.62.0":
     resolution:
       {
-        integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==,
+        integrity: sha512-IPIQ55ythEHkfEd9jMEi32OQ7SxURsGA43JI22lj01OLZNt2NUbJX8YUHxkVWyQ6daHPNn0truF5nSj3DQp6YQ==,
       }
     cpu: [arm]
     os: [android]
 
-  "@rollup/rollup-android-arm64@4.59.0":
+  "@rollup/rollup-android-arm64@4.62.0":
     resolution:
       {
-        integrity: sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==,
+        integrity: sha512-M6s9cr10MibETyo8JsOkq+Lo1+lU6hcvb1MApnUql5qte/5hMEgzlN8/ReIKNfRV8rrqX50W1BX9zoUhC192RA==,
       }
     cpu: [arm64]
     os: [android]
 
-  "@rollup/rollup-darwin-arm64@4.59.0":
+  "@rollup/rollup-darwin-arm64@4.62.0":
     resolution:
       {
-        integrity: sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==,
+        integrity: sha512-BqCoMoIbn0keKys+dEAdBa70EtOwV1bEsQCUgU9FdiZmmMge/Zk7LlkYGqbrdHR+Frnt0E1FOanly+rlwvvQzw==,
       }
     cpu: [arm64]
     os: [darwin]
 
-  "@rollup/rollup-darwin-x64@4.59.0":
+  "@rollup/rollup-darwin-x64@4.62.0":
     resolution:
       {
-        integrity: sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==,
+        integrity: sha512-SIMzST3VFNXDAbeIWDWiFCNM5qncUBDWaEV7NfE7oZbDt2mgfW4MvbKdbYiGOLoM32gbTv608UMd0XktEYSD7w==,
       }
     cpu: [x64]
     os: [darwin]
 
-  "@rollup/rollup-freebsd-arm64@4.59.0":
+  "@rollup/rollup-freebsd-arm64@4.62.0":
     resolution:
       {
-        integrity: sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==,
+        integrity: sha512-ezjfSQMP7ArdUsbBwbQIfwAlhE84I2iVnzQNCFSveqV42q+BmKlzVpf7mxv5EchLcoWU4y6/heFzVg1F+hodUQ==,
       }
     cpu: [arm64]
     os: [freebsd]
 
-  "@rollup/rollup-freebsd-x64@4.59.0":
+  "@rollup/rollup-freebsd-x64@4.62.0":
     resolution:
       {
-        integrity: sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==,
+        integrity: sha512-9+qTWGW9AZRhnUgwtTwzNwcPlL87ngkeN0LA+q1bADvmY9aNvWaF2TFW8BZgnQPYxpDI7+rMVLivcd4V737TAQ==,
       }
     cpu: [x64]
     os: [freebsd]
 
-  "@rollup/rollup-linux-arm-gnueabihf@4.59.0":
+  "@rollup/rollup-linux-arm-gnueabihf@4.62.0":
     resolution:
       {
-        integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==,
+        integrity: sha512-T1dMEQhXA/jkJ/jyMIw9IovK8bSUq7A8kLIlvZTb/6YIVsp2zLavr4F3oyllHWo7eIVJRyE5n3tUjQJEbE1IuQ==,
       }
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  "@rollup/rollup-linux-arm-musleabihf@4.59.0":
+  "@rollup/rollup-linux-arm-musleabihf@4.62.0":
     resolution:
       {
-        integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==,
+        integrity: sha512-2as0LgT7qQpyceQq6VUJYnumUMUrgGQCWIiDIN9DE0/tglsk6o66uCB4f3djRawAltvfCNLyZZrsqbPA6inCsA==,
       }
     cpu: [arm]
     os: [linux]
     libc: [musl]
 
-  "@rollup/rollup-linux-arm64-gnu@4.59.0":
+  "@rollup/rollup-linux-arm64-gnu@4.62.0":
     resolution:
       {
-        integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==,
+        integrity: sha512-bVURMg+6eNN9C/yc0aVjooZcwTTtYF4YW3xta5pP0//r3o1V8gXEHXWCndj47w/HhwsFroZrFhR+6uQP5T0n0g==,
       }
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  "@rollup/rollup-linux-arm64-musl@4.59.0":
+  "@rollup/rollup-linux-arm64-musl@4.62.0":
     resolution:
       {
-        integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==,
+        integrity: sha512-Ful8pM/2yYI83PViWdFdpZhdI8HJ5qsXANe5atypbHDf+KIBBDsZsbyy8hbXnULVvW9NsTh5DHwbcBftyLTfiw==,
       }
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  "@rollup/rollup-linux-loong64-gnu@4.59.0":
+  "@rollup/rollup-linux-loong64-gnu@4.62.0":
     resolution:
       {
-        integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==,
+        integrity: sha512-9Gp/DgrkzfUBmNPVTyPTvay+4xEP7M/clXpj3efXBcm6uTIVIgDg4rqUpqKXvLEuFRVuEpSAOkhgNeecvaZ4Cg==,
       }
     cpu: [loong64]
     os: [linux]
     libc: [glibc]
 
-  "@rollup/rollup-linux-loong64-musl@4.59.0":
+  "@rollup/rollup-linux-loong64-musl@4.62.0":
     resolution:
       {
-        integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==,
+        integrity: sha512-m9tsJz54LUXkSYM8+8PG81B9IKK5r+2T0clMq4QrS16xFosufU7firBDAZEsDheDs7wTlP7h3++S7lMsU955HA==,
       }
     cpu: [loong64]
     os: [linux]
     libc: [musl]
 
-  "@rollup/rollup-linux-ppc64-gnu@4.59.0":
+  "@rollup/rollup-linux-ppc64-gnu@4.62.0":
     resolution:
       {
-        integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==,
+        integrity: sha512-3UvJ5PNVU16aJf6M3tFI24pWzAl2/ynfbyRN3ICyQajK1lSkrnVYNnLz3v04J32qKa0FczJc22zeToc0lr2A3w==,
       }
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  "@rollup/rollup-linux-ppc64-musl@4.59.0":
+  "@rollup/rollup-linux-ppc64-musl@4.62.0":
     resolution:
       {
-        integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==,
+        integrity: sha512-vRWUAbYLGHBZS6Q8Msb2sfnf1fvJf+47t8l/TwOerM2qArzy+IeNMTHrYLHXh95h8MoatPHI5hhSZNs+mGXKPg==,
       }
     cpu: [ppc64]
     os: [linux]
     libc: [musl]
 
-  "@rollup/rollup-linux-riscv64-gnu@4.59.0":
+  "@rollup/rollup-linux-riscv64-gnu@4.62.0":
     resolution:
       {
-        integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==,
+        integrity: sha512-c00T5SYENHAt86cfW47URaP3Us5vLC/4QO7GYud1G5VNRffCwwCuBspwqYrriuJB+5m0WFzClCn9wed0FBjKvg==,
       }
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  "@rollup/rollup-linux-riscv64-musl@4.59.0":
+  "@rollup/rollup-linux-riscv64-musl@4.62.0":
     resolution:
       {
-        integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==,
+        integrity: sha512-krrCDilhXOwFkSkO3Wm9I/f9H0L92XHHwy2fwxjukxIbh0dem8gZqOW5Y8BsHrpJv5qwlRBV+Wl4ZFyRWhUpwg==,
       }
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  "@rollup/rollup-linux-s390x-gnu@4.59.0":
+  "@rollup/rollup-linux-s390x-gnu@4.62.0":
     resolution:
       {
-        integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==,
+        integrity: sha512-7pfYFSTc4/rUC/FtAI0Qp6QthDBCIi6/AuP1xYqFk5vanI6KnL5dWKP60OM/05LOsbwTmIcvr6eXC4CJuJ75IA==,
       }
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  "@rollup/rollup-linux-x64-gnu@4.59.0":
+  "@rollup/rollup-linux-x64-gnu@4.62.0":
     resolution:
       {
-        integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==,
+        integrity: sha512-7SDIalKeIpG0Ifogbbdn58HmSotYMlf23K3dCJEmiVd9Fg36Vmni82iPQec27N3wY4Bvbxftkxz6vSx9OcouTg==,
       }
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  "@rollup/rollup-linux-x64-musl@4.59.0":
+  "@rollup/rollup-linux-x64-musl@4.62.0":
     resolution:
       {
-        integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==,
+        integrity: sha512-eRZevouTH2i1HeAVLqJuLnt256krQkGY0TN6WsTmsIhuzbh457HuWDMakKwmi0Cjadux983CoSr8Lim2QhUIFw==,
       }
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  "@rollup/rollup-openbsd-x64@4.59.0":
+  "@rollup/rollup-openbsd-x64@4.62.0":
     resolution:
       {
-        integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==,
+        integrity: sha512-3oVS7FLGa4U1qcvao9ylGxrjXZyUQqR8UwxEcnUEyPX53O/C/mKDZegNXTdHCP+h3e6ta/f1EN38Yif1mmZHYg==,
       }
     cpu: [x64]
     os: [openbsd]
 
-  "@rollup/rollup-openharmony-arm64@4.59.0":
+  "@rollup/rollup-openharmony-arm64@4.62.0":
     resolution:
       {
-        integrity: sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==,
+        integrity: sha512-yTB9TgfWj5wHe5QgktAgXTLLot1gvEjl1NiPPAUiCs4oPrIWFl5V4nC3GrkNdj9LaAU4s94nVrGbGOCqUpyWsg==,
       }
     cpu: [arm64]
     os: [openharmony]
 
-  "@rollup/rollup-win32-arm64-msvc@4.59.0":
+  "@rollup/rollup-win32-arm64-msvc@4.62.0":
     resolution:
       {
-        integrity: sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==,
+        integrity: sha512-5LOhoaesY3doG1c+ac/2JtgREpKoJr5bUHH8tKY0V8di7+uSV6BwLs2PlR0/yzefGOkR+wE7ZolZphHCsyG5Rw==,
       }
     cpu: [arm64]
     os: [win32]
 
-  "@rollup/rollup-win32-ia32-msvc@4.59.0":
+  "@rollup/rollup-win32-ia32-msvc@4.62.0":
     resolution:
       {
-        integrity: sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==,
+        integrity: sha512-yYkWHhmbhRTWTnWos5HC4GcPQfjlzzCNbM9e/+GXrLuaBXYA3qSDR9f0Vgufd5S8yX81U8jPKp7ZnAjZFMtRnw==,
       }
     cpu: [ia32]
     os: [win32]
 
-  "@rollup/rollup-win32-x64-gnu@4.59.0":
+  "@rollup/rollup-win32-x64-gnu@4.62.0":
     resolution:
       {
-        integrity: sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==,
+        integrity: sha512-SoTb6lPg25xZlA2ibwQ++ahCCnH+FP0qmEuafMJ4gznZKOlXioKEAeJLgCrqjM98ACziXM9V1amFjICVL4IFoA==,
       }
     cpu: [x64]
     os: [win32]
 
-  "@rollup/rollup-win32-x64-msvc@4.59.0":
+  "@rollup/rollup-win32-x64-msvc@4.62.0":
     resolution:
       {
-        integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==,
+        integrity: sha512-5L+T1fMX4RIEBoZzT0+sQ0PhTS36NULFmMXtl1TZo44TMAROIMHbZufSOjVWt/Y622BtxgxtaNOokbTDvfsrZA==,
       }
     cpu: [x64]
     os: [win32]
 
-  "@rowanmanning/feed-parser@2.1.2":
+  "@rowanmanning/feed-parser@2.1.3":
     resolution:
       {
-        integrity: sha512-zGF+QkFMtIHcCgVx0MLKWFRghJcuzTkvCtbxR3/SU9W3DzcqBxP4xvYeasjLkGP+Lslu3yvDYTCU0uSF16FhCA==,
+        integrity: sha512-sfr85UZqCNGwPwJ8pBqnZq/vO4wrC/UEfNuCnJAtNSPPQCK7w1sfH6PAzwfNpaAK3erafFFm6m+6TKyCSFw6Bw==,
       }
     engines: { node: 20.x || 22.x || 24.x }
 
-  "@shikijs/core@3.23.0":
+  "@shikijs/core@4.2.0":
     resolution:
       {
-        integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==,
+        integrity: sha512-Hc87Ab1Ld/vEbZRCbwx344I5v+4RU8CVToUTRkqXL1+TjbuOp9U5Xa0M23V4GEWHxVn+yO5otb+HkQVm3ptWQQ==,
       }
+    engines: { node: ">=20" }
 
-  "@shikijs/engine-javascript@3.23.0":
+  "@shikijs/engine-javascript@4.2.0":
     resolution:
       {
-        integrity: sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==,
+        integrity: sha512-fjETeq1k5ffyXqRgS6+3hpvqseLalp1kjNfRbXpUgWR8FpZ1CmQfiNHovc5lncYjt/Vg5JK/WJEmLahjwMa0og==,
       }
+    engines: { node: ">=20" }
 
-  "@shikijs/engine-oniguruma@3.23.0":
+  "@shikijs/engine-oniguruma@4.2.0":
     resolution:
       {
-        integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==,
+        integrity: sha512-hTorK1dffPkpbMUk6Z+828PgRo7d07HbnizoP0hNPFjhxMHctj0Px/qoHeGMYafc6ju+u9iMldN4JbVzNQM++g==,
       }
+    engines: { node: ">=20" }
 
-  "@shikijs/langs@3.23.0":
+  "@shikijs/langs@4.2.0":
     resolution:
       {
-        integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==,
+        integrity: sha512-bwrVRlJ0wUhZxAbVdvBbv2TTC9yLsh4C/IO5Ofz0T8MQntgDvyVnkbjw9vi50r1kx7RCIJdnJnjZAwmAsXFLZQ==,
       }
+    engines: { node: ">=20" }
 
-  "@shikijs/themes@3.23.0":
+  "@shikijs/primitive@4.2.0":
     resolution:
       {
-        integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==,
+        integrity: sha512-NOq+DtUkVBJtZMVXL5A0vI0Xk8nvDYaXetFHSJFlOqjDZIVhIPRYFdGkSoElDqNuegikcc3A76SNUa8dTqtAYA==,
       }
+    engines: { node: ">=20" }
 
-  "@shikijs/types@3.23.0":
+  "@shikijs/themes@4.2.0":
     resolution:
       {
-        integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==,
+        integrity: sha512-RX8IHYeLv8Cu2W6ruc3RxUqWn0IYCqSrMBzi/uRGAmfyDNOnNO5BF/Px7o97n4XTpmFTo5GbRaazuOWj+2ak2w==,
       }
+    engines: { node: ">=20" }
+
+  "@shikijs/types@4.2.0":
+    resolution:
+      {
+        integrity: sha512-VT/MKtlpOhEPZloSH3Pb9WCZEBDoQVMa9jedp5UAwmJOar1DVc9DRODAxmYPW9M93IK4ryuqRejFfmlvlVDemw==,
+      }
+    engines: { node: ">=20" }
 
   "@shikijs/vscode-textmate@10.0.2":
     resolution:
@@ -1519,10 +1302,10 @@ packages:
         integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==,
       }
 
-  "@types/aws-lambda@8.10.161":
+  "@types/aws-lambda@8.10.162":
     resolution:
       {
-        integrity: sha512-rUYdp+MQwSFocxIOcSsYSF3YYYC/uUpMbCY/mbO21vGqfrEYvNSoPyKYDj6RhXXpPfS0KstW9RwG3qXh9sL7FQ==,
+        integrity: sha512-Fn658grtLOci1oxi1391vvDWJRKNGWRSqfxRkmN/Iy3c0tQH1USMKEXcPYHLvope+ZgTFocx9FRQJx1muBL6qw==,
       }
 
   "@types/debug@4.1.12":
@@ -1543,6 +1326,12 @@ packages:
         integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==,
       }
 
+  "@types/estree@1.0.9":
+    resolution:
+      {
+        integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==,
+      }
+
   "@types/hast@3.0.4":
     resolution:
       {
@@ -1561,10 +1350,10 @@ packages:
         integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==,
       }
 
-  "@types/mdx@2.0.13":
+  "@types/mdx@2.0.14":
     resolution:
       {
-        integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==,
+        integrity: sha512-T48PeuJtvLosNTPVhfnIp3i/n3a4g4Bad7YCq5k64D4u7NwDrAotikQ+5+sjtUvBmxCMlbo3dVL+C2dP0rWHzg==,
       }
 
   "@types/ms@2.1.0":
@@ -1579,10 +1368,10 @@ packages:
         integrity: sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==,
       }
 
-  "@types/node@17.0.45":
+  "@types/node@24.13.2":
     resolution:
       {
-        integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==,
+        integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==,
       }
 
   "@types/sax@1.2.7":
@@ -1609,10 +1398,10 @@ packages:
         integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==,
       }
 
-  "@ungap/structured-clone@1.3.0":
+  "@ungap/structured-clone@1.3.1":
     resolution:
       {
-        integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==,
+        integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==,
       }
 
   "@volar/kit@2.4.28":
@@ -1665,97 +1454,97 @@ packages:
         integrity: sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==,
       }
 
-  "@vue/compiler-core@3.5.30":
+  "@vue/compiler-core@3.5.38":
     resolution:
       {
-        integrity: sha512-s3DfdZkcu/qExZ+td75015ljzHc6vE+30cFMGRPROYjqkroYI5NV2X1yAMX9UeyBNWB9MxCfPcsjpLS11nzkkw==,
+        integrity: sha512-s99aGxWYig9ErHbct27KXEGhrBYlRI6c4MwAgXErOAbX9xiW37/uMa+XUDO69zLz83dng8UUZ70CTOJrLrYrEQ==,
       }
 
-  "@vue/compiler-dom@3.5.30":
+  "@vue/compiler-dom@3.5.38":
     resolution:
       {
-        integrity: sha512-eCFYESUEVYHhiMuK4SQTldO3RYxyMR/UQL4KdGD1Yrkfdx4m/HYuZ9jSfPdA+nWJY34VWndiYdW/wZXyiPEB9g==,
+        integrity: sha512-JTqp25l8aFfJYF7/KmsXZjAxJz7T+SjmTJLoXVjHtc2BrSgSiW2n9Aem/cWq1OPe68A8JL06B3eVdhlP0H4TVw==,
       }
 
-  "@vue/compiler-sfc@3.5.30":
+  "@vue/compiler-sfc@3.5.38":
     resolution:
       {
-        integrity: sha512-LqmFPDn89dtU9vI3wHJnwaV6GfTRD87AjWpTWpyrdVOObVtjIuSeZr181z5C4PmVx/V3j2p+0f7edFKGRMpQ5A==,
+        integrity: sha512-DuA2GiZawSEW442iw/9+Fkol8hTgb4Ke5KkhmSry65QA7YuyMbIdy8p0XZRMvNwJdgRz307W8g1CSzdvS4nuNg==,
       }
 
-  "@vue/compiler-ssr@3.5.30":
+  "@vue/compiler-ssr@3.5.38":
     resolution:
       {
-        integrity: sha512-NsYK6OMTnx109PSL2IAyf62JP6EUdk4Dmj6AkWcJGBvN0dQoMYtVekAmdqgTtWQgEJo+Okstbf/1p7qZr5H+bA==,
+        integrity: sha512-7s+W5Gc42FGxZMcuwl8H5B29T8BJPMdBT7KHFE+BbAuZ/iTEdTtv7z2XiMjiaUUw4w3ZcCEdHs36RuYJ2VA7bA==,
       }
 
-  "@vue/reactivity@3.5.30":
+  "@vue/reactivity@3.5.38":
     resolution:
       {
-        integrity: sha512-179YNgKATuwj9gB+66snskRDOitDiuOZqkYia7mHKJaidOMo/WJxHKF8DuGc4V4XbYTJANlfEKb0yxTQotnx4Q==,
+        integrity: sha512-pG6LV/NDNRbKizcUjFFLAfjaL8mcv4DmR9avNcUw2gDHBzZneuS2TWCmp633ynzxz9YYKNeEPK2I8Wraqy2HUQ==,
       }
 
-  "@vue/runtime-core@3.5.30":
+  "@vue/runtime-core@3.5.38":
     resolution:
       {
-        integrity: sha512-e0Z+8PQsUTdwV8TtEsLzUM7SzC7lQwYKePydb7K2ZnmS6jjND+WJXkmmfh/swYzRyfP1EY3fpdesyYoymCzYfg==,
+        integrity: sha512-iyW8WVfF1CpCXxncZY5Ei6rSd6oZr5DgEom//fUjRBRl56AXPD+s9ATvukRt77ZFTuYlnVA1bxY+dJB94tWVYw==,
       }
 
-  "@vue/runtime-dom@3.5.30":
+  "@vue/runtime-dom@3.5.38":
     resolution:
       {
-        integrity: sha512-2UIGakjU4WSQ0T4iwDEW0W7vQj6n7AFn7taqZ9Cvm0Q/RA2FFOziLESrDL4GmtI1wV3jXg5nMoJSYO66egDUBw==,
+        integrity: sha512-apX2wt9sdfDshS+a2xueFZLVpt0GkRJZSoPmrW/SA4yzXTznhfcMVW59gr7h4YQeY0vJhdJkk2rsIDwgfFgC5A==,
       }
 
-  "@vue/server-renderer@3.5.30":
+  "@vue/server-renderer@3.5.38":
     resolution:
       {
-        integrity: sha512-v+R34icapydRwbZRD0sXwtHqrQJv38JuMB4JxbOxd8NEpGLny7cncMp53W9UH/zo4j8eDHjQ1dEJXwzFQknjtQ==,
-      }
-    peerDependencies:
-      vue: 3.5.30
-
-  "@vue/shared@3.5.30":
-    resolution:
-      {
-        integrity: sha512-YXgQ7JjaO18NeK2K9VTbDHaFy62WrObMa6XERNfNOkAhD1F1oDSf3ZJ7K6GqabZ0BvSDHajp8qfS5Sa2I9n8uQ==,
-      }
-
-  "@vueuse/core@14.2.1":
-    resolution:
-      {
-        integrity: sha512-3vwDzV+GDUNpdegRY6kzpLm4Igptq+GA0QkJ3W61Iv27YWwW/ufSlOfgQIpN6FZRMG0mkaz4gglJRtq5SeJyIQ==,
+        integrity: sha512-vue8vbf2QlV4quHqzwmJy6dWfmRhP1J8l4wtZg60CL6VoKqcPY2oe7may3+1d9qfpedjK5PRLFqd5k3Isj9mUw==,
       }
     peerDependencies:
-      vue: ^3.5.0
+      vue: 3.5.38
 
-  "@vueuse/metadata@14.2.1":
+  "@vue/shared@3.5.38":
     resolution:
       {
-        integrity: sha512-1ButlVtj5Sb/HDtIy1HFr1VqCP4G6Ypqt5MAo0lCgjokrk2mvQKsK2uuy0vqu/Ks+sHfuHo0B9Y9jn9xKdjZsw==,
+        integrity: sha512-FTW0AFZNaK5/mOqvGBwVfUlNLU38TiQn4+DQgIFUnrBBJQ1crMJ82yeGQLV5jyKFsO8yRukpbuP7x+nRbH6aug==,
       }
 
-  "@vueuse/shared@14.2.1":
+  "@vueuse/core@14.3.0":
     resolution:
       {
-        integrity: sha512-shTJncjV9JTI4oVNyF1FQonetYAiTBd+Qj7cY89SWbXSkx7gyhrgtEdF2ZAVWS1S3SHlaROO6F2IesJxQEkZBw==,
+        integrity: sha512-aHfz47g0ZhMtTVHmIzMVpJy8ePhhOy68GY5bv110+5DVtZ+W7BsOx+m61UNQqfrWyPztIHIanWa3E2tib3NFIw==,
       }
     peerDependencies:
       vue: ^3.5.0
 
-  "@waline/api@1.1.0":
+  "@vueuse/metadata@14.3.0":
     resolution:
       {
-        integrity: sha512-mLBwZ6iicZHx1VUzthO+pk+2uD6byPRHjK+OI0pLH7PP+Qx3Gtx9xuiKL6Xxi58WrcAi8CIN2HyGVJbkNESwnA==,
+        integrity: sha512-BwxmbAzwAVF50+MW57GXOUEV61nFBGnlBvrTqj49PqWJu3uw7hdu72ztXeZ33RdZtDY6kO+bfCAE1PCn88Tktw==,
       }
-    engines: { node: ">=18" }
 
-  "@waline/client@3.13.0":
+  "@vueuse/shared@14.3.0":
     resolution:
       {
-        integrity: sha512-iBVAjf1j4wgxNB8zF3/IPprJvC6cD+OlCwfuoRZWoe6x6dc/NiPXe8LrtZLL0foLiD7Unsc71JvQJASg2vlWfw==,
+        integrity: sha512-bZpge9eSXwa4ToSiqJ7j6KRwhAsneMFoSz3LMWKQDkqimm3D/tbFlrklrs/IOqC8tEcYmXQZJ6N0UrjhBirVCg==,
       }
-    engines: { node: ">=18" }
+    peerDependencies:
+      vue: ^3.5.0
+
+  "@waline/api@1.1.2":
+    resolution:
+      {
+        integrity: sha512-r1H+XL+/Ww4qXv8vjq09HJQtMvYqMofgfueuokgsDW1kJ9/6CYY7g6LkksYlDJmWm0aqkLR/9ZTI/bbozL4FBA==,
+      }
+    engines: { node: ">=22" }
+
+  "@waline/client@3.15.2":
+    resolution:
+      {
+        integrity: sha512-QBAVbruefDR+IKyQdM/Ao9fd07Xxpx1WEJ7xI8lBVNDjMQBr1PpdwrTpLC8RrYbgUR9ymNBvtLDJi0xK3pbORQ==,
+      }
+    engines: { node: ">=22" }
 
   acorn-jsx@5.3.2:
     resolution:
@@ -1773,6 +1562,14 @@ packages:
     engines: { node: ">=0.4.0" }
     hasBin: true
 
+  acorn@8.17.0:
+    resolution:
+      {
+        integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==,
+      }
+    engines: { node: ">=0.4.0" }
+    hasBin: true
+
   ajv-draft-04@1.0.0:
     resolution:
       {
@@ -1784,16 +1581,18 @@ packages:
       ajv:
         optional: true
 
-  ajv@8.18.0:
+  ajv-i18n@4.2.0:
     resolution:
       {
-        integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==,
+        integrity: sha512-v/ei2UkCEeuKNXh8RToiFsUclmU+G57LO1Oo22OagNMENIw+Yb8eMwvHu7Vn9fmkjJyv6XclhJ8TbuigSglPkg==,
       }
+    peerDependencies:
+      ajv: ^8.0.0-beta.0
 
-  ansi-align@3.0.1:
+  ajv@8.20.0:
     resolution:
       {
-        integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==,
+        integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==,
       }
 
   ansi-regex@5.0.1:
@@ -1803,13 +1602,6 @@ packages:
       }
     engines: { node: ">=8" }
 
-  ansi-regex@6.2.2:
-    resolution:
-      {
-        integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==,
-      }
-    engines: { node: ">=12" }
-
   ansi-styles@4.3.0:
     resolution:
       {
@@ -1817,19 +1609,18 @@ packages:
       }
     engines: { node: ">=8" }
 
-  ansi-styles@6.2.3:
-    resolution:
-      {
-        integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==,
-      }
-    engines: { node: ">=12" }
-
   anymatch@3.1.3:
     resolution:
       {
         integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==,
       }
     engines: { node: ">= 8" }
+
+  anynum@1.0.0:
+    resolution:
+      {
+        integrity: sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==,
+      }
 
   arg@5.0.2:
     resolution:
@@ -1872,21 +1663,21 @@ packages:
     peerDependencies:
       astro: ^5.0.0-beta || ^6.0.0-alpha
 
-  astro-loader-bluesky-posts@1.2.3:
+  astro-loader-bluesky-posts@1.2.4:
     resolution:
       {
-        integrity: sha512-2vylnvIx+aucHu1sicP6Vk9C6R0FbKNwAhRe2UAM157+uyiQnlZ9Hvcg9H+CK9mSXERtxnCJ+GPs92QYXYZbRQ==,
+        integrity: sha512-iz1BZCEE25GTnYlX1vZW7fkMRfl87ZIE8prq7ggRXm5b9Y0eWfSPYTeCcXXQLalU174vIdTZrCcjOX4uRsTQtA==,
       }
     peerDependencies:
-      astro: ">=4.14.0 <6.0.0"
+      astro: ">=4.14.0 <7.0.0"
 
-  astro-loader-github-prs@1.3.1:
+  astro-loader-github-prs@2.0.0:
     resolution:
       {
-        integrity: sha512-BPVcFOrwiOul0FzJsD+wayforzI7nL9dc4inaTQcGQSDCB3kgoiPItm3I7ZYJXSoAVORxjrDSqoXBDSmKhN0IQ==,
+        integrity: sha512-nsgSmN3SwHnpHsfwO5UnIcjmfSf2HclBrLXzfDOTJVgTMqrEnH3FtTukyHyHtSdQivlPOgHoFccD6lsX3r9lGw==,
       }
     peerDependencies:
-      astro: ">=4.14.0 <6.0.0"
+      astro: ">=4.14.0 <7.0.0"
 
   astro-robots-txt@1.0.0:
     resolution:
@@ -1894,13 +1685,12 @@ packages:
         integrity: sha512-6JQSLid4gMhoWjOm85UHLkgrw0+hHIjnJVIUqxjU2D6feKlVyYukMNYjH44ZDZBK1P8hNxd33PgWlHzCASvedA==,
       }
 
-  astro@5.18.0:
+  astro@6.4.8:
     resolution:
       {
-        integrity: sha512-CHiohwJIS4L0G6/IzE1Fx3dgWqXBCXus/od0eGUfxrZJD2um2pE7ehclMmgL/fXqbU7NfE1Ze2pq34h2QaA6iQ==,
+        integrity: sha512-KK5lX90uU9EeVaTjINyj3sy9/NFXVa59aowaqbWBDDKLXZh4rr7GwIaCFYVetE22MJtsCNFerQXn0vlCLmpP/Q==,
       }
-    engines:
-      { node: 18.20.8 || ^20.3.0 || >=22.0.0, npm: ">=9.6.5", pnpm: ">=7.1.0" }
+    engines: { node: ">=22.12.0", npm: ">=9.6.5", pnpm: ">=7.1.0" }
     hasBin: true
 
   autosize@6.0.1:
@@ -1909,10 +1699,10 @@ packages:
         integrity: sha512-f86EjiUKE6Xvczc4ioP1JBlWG7FKrE13qe/DxBCpe8GCipCq2nFw73aO8QEBKHfSbYGDN5eB9jXWKen7tspDqQ==,
       }
 
-  await-lock@2.2.2:
+  await-lock@3.0.0:
     resolution:
       {
-        integrity: sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==,
+        integrity: sha512-eO6fLiSnrJrMdjWMNK8zbVRXPs2TKJg78iKZd9wDpN3na5tcoV6EoeiOlMgk2QaAQ1gIrK1YuMsJHXWqz89tSA==,
       }
 
   axobject-query@4.1.0:
@@ -1926,12 +1716,6 @@ packages:
     resolution:
       {
         integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==,
-      }
-
-  base-64@1.0.0:
-    resolution:
-      {
-        integrity: sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==,
       }
 
   base64-js@1.5.1:
@@ -1977,13 +1761,6 @@ packages:
         integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==,
       }
 
-  boxen@8.0.1:
-    resolution:
-      {
-        integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==,
-      }
-    engines: { node: ">=18" }
-
   bson@7.2.0:
     resolution:
       {
@@ -1997,25 +1774,11 @@ packages:
         integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==,
       }
 
-  camelcase@8.0.0:
-    resolution:
-      {
-        integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==,
-      }
-    engines: { node: ">=16" }
-
   ccount@2.0.1:
     resolution:
       {
         integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==,
       }
-
-  chalk@5.6.2:
-    resolution:
-      {
-        integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==,
-      }
-    engines: { node: ^12.17.0 || ^14.13 || >=16.0.0 }
 
   character-entities-html4@2.1.0:
     resolution:
@@ -2075,13 +1838,6 @@ packages:
       }
     engines: { node: ">=8" }
 
-  cli-boxes@3.0.0:
-    resolution:
-      {
-        integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==,
-      }
-    engines: { node: ">=10" }
-
   cliui@8.0.1:
     resolution:
       {
@@ -2135,16 +1891,24 @@ packages:
       }
     engines: { node: ">= 12" }
 
-  common-ancestor-path@1.0.1:
+  common-ancestor-path@2.0.0:
     resolution:
       {
-        integrity: sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==,
+        integrity: sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==,
       }
+    engines: { node: ">= 18" }
 
-  cookie-es@1.2.2:
+  content-type@2.0.0:
     resolution:
       {
-        integrity: sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg==,
+        integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==,
+      }
+    engines: { node: ">=18" }
+
+  cookie-es@1.2.3:
+    resolution:
+      {
+        integrity: sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==,
       }
 
   cookie@1.1.1:
@@ -2173,10 +1937,10 @@ packages:
       }
     engines: { node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: ">=7.0.0" }
 
-  css-tree@3.1.0:
+  css-tree@3.2.1:
     resolution:
       {
-        integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==,
+        integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==,
       }
     engines: { node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0 }
 
@@ -2186,14 +1950,6 @@ packages:
         integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==,
       }
     engines: { node: ">= 6" }
-
-  cssesc@3.0.0:
-    resolution:
-      {
-        integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==,
-      }
-    engines: { node: ">=4" }
-    hasBin: true
 
   csso@5.0.5:
     resolution:
@@ -2240,10 +1996,10 @@ packages:
       }
     engines: { node: ">=4.0.0" }
 
-  defu@6.1.4:
+  defu@6.1.7:
     resolution:
       {
-        integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==,
+        integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==,
       }
 
   depd@2.0.0:
@@ -2273,17 +2029,10 @@ packages:
       }
     engines: { node: ">=8" }
 
-  deterministic-object-hash@2.0.2:
+  devalue@5.8.1:
     resolution:
       {
-        integrity: sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==,
-      }
-    engines: { node: ">=18" }
-
-  devalue@5.6.3:
-    resolution:
-      {
-        integrity: sha512-nc7XjUU/2Lb+SvEFVGcWLiKkzfw8+qHI7zn8WYXKkLMgfGSHbgCEaR6bJpev8Cm6Rmrb19Gfd/tZvGqx9is3wg==,
+        integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==,
       }
 
   devlop@1.1.0:
@@ -2292,18 +2041,12 @@ packages:
         integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==,
       }
 
-  diff@8.0.3:
+  diff@8.0.4:
     resolution:
       {
-        integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==,
+        integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==,
       }
     engines: { node: ">=0.3.1" }
-
-  dlv@1.1.3:
-    resolution:
-      {
-        integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==,
-      }
 
   dom-serializer@2.0.0:
     resolution:
@@ -2349,12 +2092,6 @@ packages:
         integrity: sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ==,
       }
 
-  emoji-regex@10.6.0:
-    resolution:
-      {
-        integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==,
-      }
-
   emoji-regex@8.0.0:
     resolution:
       {
@@ -2395,10 +2132,10 @@ packages:
       }
     engines: { node: ">=0.12" }
 
-  es-module-lexer@1.7.0:
+  es-module-lexer@2.1.0:
     resolution:
       {
-        integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==,
+        integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==,
       }
 
   esast-util-from-estree@2.0.0:
@@ -2413,18 +2150,10 @@ packages:
         integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==,
       }
 
-  esbuild@0.25.12:
+  esbuild@0.28.1:
     resolution:
       {
-        integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==,
-      }
-    engines: { node: ">=18" }
-    hasBin: true
-
-  esbuild@0.27.3:
-    resolution:
-      {
-        integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==,
+        integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==,
       }
     engines: { node: ">=18" }
     hasBin: true
@@ -2523,34 +2252,46 @@ packages:
         integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==,
       }
 
-  fast-content-type-parse@3.0.0:
-    resolution:
-      {
-        integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==,
-      }
-
   fast-deep-equal@3.1.3:
     resolution:
       {
         integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==,
       }
 
-  fast-uri@3.1.0:
+  fast-string-truncated-width@3.0.3:
     resolution:
       {
-        integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==,
+        integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==,
       }
 
-  fast-xml-builder@1.0.0:
+  fast-string-width@3.0.2:
     resolution:
       {
-        integrity: sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==,
+        integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==,
       }
 
-  fast-xml-parser@5.4.2:
+  fast-uri@3.1.2:
     resolution:
       {
-        integrity: sha512-pw/6pIl4k0CSpElPEJhDppLzaixDEuWui2CUQQBH/ECDf7+y6YwA4Gf7Tyb0Rfe4DIMuZipYj4AEL0nACKglvQ==,
+        integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==,
+      }
+
+  fast-wrap-ansi@0.2.2:
+    resolution:
+      {
+        integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==,
+      }
+
+  fast-xml-builder@1.2.0:
+    resolution:
+      {
+        integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==,
+      }
+
+  fast-xml-parser@5.9.2:
+    resolution:
+      {
+        integrity: sha512-DYPkXnVSJHAGAkSBeVYhEo/seIpz2SLr9OQcX7m6lXaX3gvoB+DCKzFdZIEhZGI3I1DUhObBAUOT/v2xfoXz/w==,
       }
     hasBin: true
 
@@ -2592,10 +2333,10 @@ packages:
         integrity: sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw==,
       }
 
-  fontkitten@1.0.2:
+  fontkitten@1.0.3:
     resolution:
       {
-        integrity: sha512-piJxbLnkD9Xcyi7dWJRnqszEURixe7CrF/efBfbffe2DPyabmuIuqraruY8cXTs19QoM8VJzx47BDRVNXETM7Q==,
+        integrity: sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==,
       }
     engines: { node: ">=20" }
 
@@ -2627,12 +2368,12 @@ packages:
       }
     engines: { node: 6.* || 8.* || >= 10.* }
 
-  get-east-asian-width@1.5.0:
+  get-tsconfig@5.0.0-beta.4:
     resolution:
       {
-        integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==,
+        integrity: sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ==,
       }
-    engines: { node: ">=18" }
+    engines: { node: ">=20.20.0" }
 
   github-from-package@0.0.0:
     resolution:
@@ -2646,10 +2387,10 @@ packages:
         integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==,
       }
 
-  h3@1.15.5:
+  h3@1.15.11:
     resolution:
       {
-        integrity: sha512-xEyq3rSl+dhGX2Lm0+eFQIAzlDN6Fs0EcC4f7BNUmzaRX/PTzeuM+Tr2lHB8FoXggsQIeXLj8EDVgs5ywxyxmg==,
+        integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==,
       }
 
   hast-util-from-dom@5.0.1:
@@ -2773,12 +2514,6 @@ packages:
         integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==,
       }
 
-  import-meta-resolve@4.2.0:
-    resolution:
-      {
-        integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==,
-      }
-
   inherits@2.0.4:
     resolution:
       {
@@ -2829,6 +2564,14 @@ packages:
     engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
     hasBin: true
 
+  is-docker@4.0.0:
+    resolution:
+      {
+        integrity: sha512-LHE+wROyG/Y/0ZnbktRCoTix2c1RhgWaZraMZ8o1Q7zCh0VSrICJQO5oqIIISrcSBtrXv0o233w1IYwsWCjTzA==,
+      }
+    engines: { node: ">=20" }
+    hasBin: true
+
   is-fullwidth-code-point@3.0.0:
     resolution:
       {
@@ -2857,6 +2600,12 @@ packages:
       }
     engines: { node: ">=12" }
 
+  is-unsafe@1.0.1:
+    resolution:
+      {
+        integrity: sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==,
+      }
+
   is-wsl@3.1.1:
     resolution:
       {
@@ -2870,10 +2619,10 @@ packages:
         integrity: sha512-yLEMkBbLZTlVQqOnQ4FiMujR6T4DEcCb1xizmvXS+OxuhwcbtynoosRzdMA69zZCShCNAbi+gJ71FxZBBXx1SA==,
       }
 
-  js-yaml@4.1.1:
+  js-yaml@4.2.0:
     resolution:
       {
-        integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==,
+        integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==,
       }
     hasBin: true
 
@@ -2883,10 +2632,10 @@ packages:
         integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==,
       }
 
-  json-with-bigint@3.5.7:
+  json-with-bigint@3.5.8:
     resolution:
       {
-        integrity: sha512-7ei3MdAI5+fJPVnKlW77TKNKwQ5ppSzWvhPuSuINT/GYW9ZOC1eRKOuhV9yHG5aEsUPj9BBx5JIekkmoLHxZOw==,
+        integrity: sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==,
       }
 
   jsonc-parser@2.3.1:
@@ -2908,13 +2657,6 @@ packages:
       }
     hasBin: true
 
-  kleur@3.0.3:
-    resolution:
-      {
-        integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==,
-      }
-    engines: { node: ">=6" }
-
   kleur@4.1.5:
     resolution:
       {
@@ -2922,22 +2664,16 @@ packages:
       }
     engines: { node: ">=6" }
 
-  lodash@4.17.21:
-    resolution:
-      {
-        integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==,
-      }
-
   longest-streak@3.1.0:
     resolution:
       {
         integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==,
       }
 
-  lru-cache@11.2.6:
+  lru-cache@11.5.1:
     resolution:
       {
-        integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==,
+        integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==,
       }
     engines: { node: 20 || >=22 }
 
@@ -2953,10 +2689,10 @@ packages:
         integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==,
       }
 
-  magicast@0.5.2:
+  magicast@0.5.3:
     resolution:
       {
-        integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==,
+        integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==,
       }
 
   markdown-extensions@2.0.0:
@@ -2972,18 +2708,18 @@ packages:
         integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==,
       }
 
-  marked-highlight@2.2.3:
+  marked-highlight@2.2.4:
     resolution:
       {
-        integrity: sha512-FCfZRxW/msZAiasCML4isYpxyQWKEEx44vOgdn5Kloae+Qc3q4XR7WjpKKf8oMLk7JP9ZCRd2vhtclJFdwxlWQ==,
+        integrity: sha512-PZxisNMJDduSjc0q6uvjsnqqHCXc9s0eyzxDO9sB1eNGJnd/H1/Fu+z6g/liC1dfJdFW4SftMwMlLvsBhUPrqQ==,
       }
     peerDependencies:
-      marked: ">=4 <18"
+      marked: ">=4 <19"
 
-  marked@17.0.4:
+  marked@18.0.5:
     resolution:
       {
-        integrity: sha512-NOmVMM+KAokHMvjWmC5N/ZOvgmSWuqJB8FoYI019j4ogb/PeRMKoKIjReZ2w3376kkA8dSJIP8uD993Kxc0iRQ==,
+        integrity: sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==,
       }
     engines: { node: ">= 20" }
     hasBin: true
@@ -3108,10 +2844,10 @@ packages:
         integrity: sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==,
       }
 
-  mdn-data@2.12.2:
+  mdn-data@2.27.1:
     resolution:
       {
-        integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==,
+        integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==,
       }
 
   micromark-core-commonmark@2.0.3:
@@ -3402,16 +3138,16 @@ packages:
         integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==,
       }
 
-  multiformats@9.9.0:
+  multiformats@13.4.2:
     resolution:
       {
-        integrity: sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==,
+        integrity: sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==,
       }
 
-  nanoid@3.3.11:
+  nanoid@3.3.12:
     resolution:
       {
-        integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==,
+        integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==,
       }
     engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
     hasBin: true
@@ -3467,6 +3203,13 @@ packages:
         integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==,
       }
 
+  obug@2.1.3:
+    resolution:
+      {
+        integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==,
+      }
+    engines: { node: ">=12.20.0" }
+
   octokit@5.0.5:
     resolution:
       {
@@ -3499,38 +3242,38 @@ packages:
         integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==,
       }
 
-  oniguruma-parser@0.12.1:
+  oniguruma-parser@0.12.2:
     resolution:
       {
-        integrity: sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==,
+        integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==,
       }
 
-  oniguruma-to-es@4.3.4:
+  oniguruma-to-es@4.3.6:
     resolution:
       {
-        integrity: sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA==,
+        integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==,
       }
 
-  p-limit@6.2.0:
+  p-limit@7.3.0:
     resolution:
       {
-        integrity: sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==,
+        integrity: sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==,
       }
-    engines: { node: ">=18" }
+    engines: { node: ">=20" }
 
-  p-queue@8.1.1:
+  p-queue@9.3.0:
     resolution:
       {
-        integrity: sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==,
+        integrity: sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==,
       }
-    engines: { node: ">=18" }
+    engines: { node: ">=20" }
 
-  p-timeout@6.1.4:
+  p-timeout@7.0.1:
     resolution:
       {
-        integrity: sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==,
+        integrity: sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==,
       }
-    engines: { node: ">=14.16" }
+    engines: { node: ">=20" }
 
   package-manager-detector@1.6.0:
     resolution:
@@ -3562,6 +3305,13 @@ packages:
         integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==,
       }
 
+  path-expression-matcher@1.5.0:
+    resolution:
+      {
+        integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==,
+      }
+    engines: { node: ">=14.0.0" }
+
   piccolore@0.1.3:
     resolution:
       {
@@ -3574,24 +3324,24 @@ packages:
         integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==,
       }
 
-  picomatch@2.3.1:
+  picomatch@2.3.2:
     resolution:
       {
-        integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==,
+        integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==,
       }
     engines: { node: ">=8.6" }
 
-  picomatch@4.0.3:
+  picomatch@4.0.4:
     resolution:
       {
-        integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==,
+        integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==,
       }
     engines: { node: ">=12" }
 
-  postcss@8.5.8:
+  postcss@8.5.15:
     resolution:
       {
-        integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==,
+        integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==,
       }
     engines: { node: ^10 || ^12 || >=14 }
 
@@ -3611,10 +3361,10 @@ packages:
       }
     engines: { node: ^14.15.0 || >=16.0.0 }
 
-  prettier@3.8.1:
+  prettier@3.8.4:
     resolution:
       {
-        integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==,
+        integrity: sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==,
       }
     engines: { node: ">=14" }
     hasBin: true
@@ -3626,17 +3376,16 @@ packages:
       }
     engines: { node: ">=6" }
 
-  prompts@2.4.2:
-    resolution:
-      {
-        integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==,
-      }
-    engines: { node: ">= 6" }
-
   property-information@7.1.0:
     resolution:
       {
         integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==,
+      }
+
+  property-information@7.2.0:
+    resolution:
+      {
+        integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==,
       }
 
   pump@3.0.4:
@@ -3847,6 +3596,12 @@ packages:
       }
     engines: { node: ">=0.10.0" }
 
+  resolve-pkg-maps@1.0.0:
+    resolution:
+      {
+        integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==,
+      }
+
   retext-latin@4.0.0:
     resolution:
       {
@@ -3871,10 +3626,10 @@ packages:
         integrity: sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==,
       }
 
-  rollup@4.59.0:
+  rollup@4.62.0:
     resolution:
       {
-        integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==,
+        integrity: sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA==,
       }
     engines: { node: ">=18.0.0", npm: ">=8.0.0" }
     hasBin: true
@@ -3897,10 +3652,10 @@ packages:
         integrity: sha512-CWZ8XiSim+fJVG0cFLStwDvft1VI7uvXdCNJYXhDvowiv+DsbD1nXLiQ4zrE5UBvj5DWZJ93cwN0NX5PMsr1Pw==,
       }
 
-  sax@1.5.0:
+  sax@1.6.0:
     resolution:
       {
-        integrity: sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==,
+        integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==,
       }
     engines: { node: ">=11.0.0" }
 
@@ -3908,6 +3663,14 @@ packages:
     resolution:
       {
         integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==,
+      }
+    engines: { node: ">=10" }
+    hasBin: true
+
+  semver@7.8.4:
+    resolution:
+      {
+        integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==,
       }
     engines: { node: ">=10" }
     hasBin: true
@@ -3938,11 +3701,12 @@ packages:
       }
     engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
 
-  shiki@3.23.0:
+  shiki@4.2.0:
     resolution:
       {
-        integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==,
+        integrity: sha512-hjNax6o/ylDy9lefQEaSDtzaT3iVNtZ3WmpQnbuQNoG4xvnSKf2kSKbihZVO4JRG1TTMejs7CmNRYlWgAL66pQ==,
       }
+    engines: { node: ">=20" }
 
   simple-concat@1.0.1:
     resolution:
@@ -3962,18 +3726,18 @@ packages:
         integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==,
       }
 
-  sitemap@8.0.3:
+  sitemap@9.0.1:
     resolution:
       {
-        integrity: sha512-9Ew1tR2WYw8RGE2XLy7GjkusvYXy8Rg6y8TYuBuQMfIEdGcWoJpY2Wr5DzsEiL/TKCw56+YKTCCUHglorEYK+A==,
+        integrity: sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ==,
       }
-    engines: { node: ">=14.0.0", npm: ">=6.0.0" }
+    engines: { node: ">=20.19.5", npm: ">=10.8.2" }
     hasBin: true
 
-  smol-toml@1.6.0:
+  smol-toml@1.6.1:
     resolution:
       {
-        integrity: sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==,
+        integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==,
       }
     engines: { node: ">= 18" }
 
@@ -4017,13 +3781,6 @@ packages:
       }
     engines: { node: ">=8" }
 
-  string-width@7.2.0:
-    resolution:
-      {
-        integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==,
-      }
-    engines: { node: ">=18" }
-
   string_decoder@1.3.0:
     resolution:
       {
@@ -4043,13 +3800,6 @@ packages:
       }
     engines: { node: ">=8" }
 
-  strip-ansi@7.2.0:
-    resolution:
-      {
-        integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==,
-      }
-    engines: { node: ">=12" }
-
   strip-json-comments@2.0.1:
     resolution:
       {
@@ -4057,10 +3807,10 @@ packages:
       }
     engines: { node: ">=0.10.0" }
 
-  strnum@2.2.0:
+  strnum@2.4.0:
     resolution:
       {
-        integrity: sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==,
+        integrity: sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==,
       }
 
   style-to-js@1.1.21:
@@ -4081,10 +3831,10 @@ packages:
         integrity: sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==,
       }
 
-  svgo@4.0.0:
+  svgo@4.0.1:
     resolution:
       {
-        integrity: sha512-VvrHQ+9uniE+Mvx3+C9IEe/lWasXCU0nXMY2kZeLrHNICuRiC8uMPyM14UEaMOFA5mhyQqEkB02VoQ16n3DLaw==,
+        integrity: sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==,
       }
     engines: { node: ">=16" }
     hasBin: true
@@ -4102,10 +3852,10 @@ packages:
       }
     engines: { node: ">=6" }
 
-  tar@7.5.11:
+  tar@7.5.16:
     resolution:
       {
-        integrity: sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==,
+        integrity: sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==,
       }
     engines: { node: ">=18" }
 
@@ -4115,17 +3865,24 @@ packages:
         integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==,
       }
 
-  tinyexec@1.0.2:
+  tinyclip@0.1.14:
     resolution:
       {
-        integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==,
+        integrity: sha512-F1oWdz8tjT17qe1d5JgDK6z03WGOhYYAN0lK3/D/fzNiy93xswLLEw7pk+3g05onhAy6Bsc6PLNUGhdgVjemMQ==,
+      }
+    engines: { node: ^16.14.0 || >= 17.3.0 }
+
+  tinyexec@1.2.4:
+    resolution:
+      {
+        integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==,
       }
     engines: { node: ">=18" }
 
-  tinyglobby@0.2.15:
+  tinyglobby@0.2.17:
     resolution:
       {
-        integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==,
+        integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==,
       }
     engines: { node: ">=12.0.0" }
 
@@ -4136,12 +3893,12 @@ packages:
       }
     hasBin: true
 
-  toad-cache@3.7.0:
+  toad-cache@3.7.1:
     resolution:
       {
-        integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==,
+        integrity: sha512-5DXWzE4Vz7xNHsv+xQ+MGfJYyC78Aok3tEr0MNwHoRf7vZnga1mQXZ4/Nsodld4VR6Wd+VhfmqnNrsRJyYPfrQ==,
       }
-    engines: { node: ">=12" }
+    engines: { node: ">=20" }
 
   toidentifier@1.0.1:
     resolution:
@@ -4162,19 +3919,6 @@ packages:
         integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==,
       }
 
-  tsconfck@3.1.6:
-    resolution:
-      {
-        integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==,
-      }
-    engines: { node: ^18 || >=20 }
-    hasBin: true
-    peerDependencies:
-      typescript: ^5.0.0
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   tslib@2.8.1:
     resolution:
       {
@@ -4186,13 +3930,6 @@ packages:
       {
         integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==,
       }
-
-  type-fest@4.41.0:
-    resolution:
-      {
-        integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==,
-      }
-    engines: { node: ">=16" }
 
   typesafe-path@0.2.2:
     resolution:
@@ -4214,16 +3951,16 @@ packages:
     engines: { node: ">=14.17" }
     hasBin: true
 
-  ufo@1.6.3:
+  ufo@1.6.4:
     resolution:
       {
-        integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==,
+        integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==,
       }
 
-  uint8arrays@3.0.0:
+  uint8arrays@5.1.1:
     resolution:
       {
-        integrity: sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==,
+        integrity: sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==,
       }
 
   ultrahtml@1.6.0:
@@ -4236,6 +3973,12 @@ packages:
     resolution:
       {
         integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==,
+      }
+
+  undici-types@7.18.2:
+    resolution:
+      {
+        integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==,
       }
 
   unicode-segmenter@0.14.5:
@@ -4328,10 +4071,10 @@ packages:
         integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==,
       }
 
-  unstorage@1.17.4:
+  unstorage@1.17.5:
     resolution:
       {
-        integrity: sha512-fHK0yNg38tBiJKp/Vgsq4j0JEsCmgqH58HAn707S7zGkArbZsVr/CwINoi+nh3h98BRCwKvx1K3Xg9u3VV83sw==,
+        integrity: sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==,
       }
     peerDependencies:
       "@azure/app-configuration": ^1.8.0
@@ -4424,22 +4167,22 @@ packages:
         integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==,
       }
 
-  vite@6.4.1:
+  vite@7.3.5:
     resolution:
       {
-        integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==,
+        integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==,
       }
-    engines: { node: ^18.0.0 || ^20.0.0 || >=22.0.0 }
+    engines: { node: ^20.19.0 || >=22.12.0 }
     hasBin: true
     peerDependencies:
-      "@types/node": ^18.0.0 || ^20.0.0 || >=22.0.0
+      "@types/node": ^20.19.0 || >=22.12.0
       jiti: ">=1.21.0"
-      less: "*"
+      less: ^4.0.0
       lightningcss: ^1.21.0
-      sass: "*"
-      sass-embedded: "*"
-      stylus: "*"
-      sugarss: "*"
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: ">=0.54.8"
+      sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
       yaml: ^2.4.2
@@ -4467,21 +4210,21 @@ packages:
       yaml:
         optional: true
 
-  vitefu@1.1.2:
+  vitefu@1.1.3:
     resolution:
       {
-        integrity: sha512-zpKATdUbzbsycPFBN71nS2uzBUQiVnFoOrr2rvqv34S1lcAgMKKkjWleLGeiJlZ8lwCXvtWaRn7R3ZC16SYRuw==,
+        integrity: sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==,
       }
     peerDependencies:
-      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-beta.0
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       vite:
         optional: true
 
-  volar-service-css@0.0.68:
+  volar-service-css@0.0.70:
     resolution:
       {
-        integrity: sha512-lJSMh6f3QzZ1tdLOZOzovLX0xzAadPhx8EKwraDLPxBndLCYfoTvnNuiFFV8FARrpAlW5C0WkH+TstPaCxr00Q==,
+        integrity: sha512-K1qyOvBpE3rzdAv3e4/6Rv5yizrYPy5R/ne3IWCAzLBuMO4qBMV3kSqWzj6KUVe6S0AnN6wxF7cRkiaKfYMYJw==,
       }
     peerDependencies:
       "@volar/language-service": ~2.4.0
@@ -4489,10 +4232,10 @@ packages:
       "@volar/language-service":
         optional: true
 
-  volar-service-emmet@0.0.68:
+  volar-service-emmet@0.0.70:
     resolution:
       {
-        integrity: sha512-nHvixrRQ83EzkQ4G/jFxu9Y4eSsXS/X2cltEPDM+K9qZmIv+Ey1w0tg1+6caSe8TU5Hgw4oSTwNMf/6cQb3LzQ==,
+        integrity: sha512-xi5bC4m/VyE3zy/n2CXspKeDZs3qA41tHLTw275/7dNWM/RqE2z3BnDICQybHIVp/6G1iOQj5c1qXMgQC08TNg==,
       }
     peerDependencies:
       "@volar/language-service": ~2.4.0
@@ -4500,10 +4243,10 @@ packages:
       "@volar/language-service":
         optional: true
 
-  volar-service-html@0.0.68:
+  volar-service-html@0.0.70:
     resolution:
       {
-        integrity: sha512-fru9gsLJxy33xAltXOh4TEdi312HP80hpuKhpYQD4O5hDnkNPEBdcQkpB+gcX0oK0VxRv1UOzcGQEUzWCVHLfA==,
+        integrity: sha512-eR6vCgMdmYAo4n+gcT7DSyBQbwB8S3HZZvSagTf0sxNaD4WppMCFfpqWnkrlGStPKMZvMiejRRVmqsX9dYcTvQ==,
       }
     peerDependencies:
       "@volar/language-service": ~2.4.0
@@ -4511,10 +4254,10 @@ packages:
       "@volar/language-service":
         optional: true
 
-  volar-service-prettier@0.0.68:
+  volar-service-prettier@0.0.70:
     resolution:
       {
-        integrity: sha512-grUmWHkHlebMOd6V8vXs2eNQUw/bJGJMjekh/EPf/p2ZNTK0Uyz7hoBRngcvGfJHMsSXZH8w/dZTForIW/4ihw==,
+        integrity: sha512-Z6BCFSpGVCd8BPAsZ785Kce1BGlWd5ODqmqZGVuB14MJvrR4+CYz6cDy4F+igmE1gMifqfvMhdgT8Aud4M5ngg==,
       }
     peerDependencies:
       "@volar/language-service": ~2.4.0
@@ -4525,10 +4268,10 @@ packages:
       prettier:
         optional: true
 
-  volar-service-typescript-twoslash-queries@0.0.68:
+  volar-service-typescript-twoslash-queries@0.0.70:
     resolution:
       {
-        integrity: sha512-NugzXcM0iwuZFLCJg47vI93su5YhTIweQuLmZxvz5ZPTaman16JCvmDZexx2rd5T/75SNuvvZmrTOTNYUsfe5w==,
+        integrity: sha512-IdD13Z9N2Bu8EM6CM0fDV1E69olEYGHDU25X51YXmq8Y0CmJ2LNj6gOiBJgpS5JGUqFzECVhMNBW7R0sPdRTMQ==,
       }
     peerDependencies:
       "@volar/language-service": ~2.4.0
@@ -4536,10 +4279,10 @@ packages:
       "@volar/language-service":
         optional: true
 
-  volar-service-typescript@0.0.68:
+  volar-service-typescript@0.0.70:
     resolution:
       {
-        integrity: sha512-z7B/7CnJ0+TWWFp/gh2r5/QwMObHNDiQiv4C9pTBNI2Wxuwymd4bjEORzrJ/hJ5Yd5+OzeYK+nFCKevoGEEeKw==,
+        integrity: sha512-l46Bx4cokkUedTd74ojO5H/zqHZJ8SUuyZ0IB8JN4jfRqUM3bQFBHoOwlZCyZmOeO0A3RQNkMnFclxO4c++gsg==,
       }
     peerDependencies:
       "@volar/language-service": ~2.4.0
@@ -4547,10 +4290,10 @@ packages:
       "@volar/language-service":
         optional: true
 
-  volar-service-yaml@0.0.68:
+  volar-service-yaml@0.0.71:
     resolution:
       {
-        integrity: sha512-84XgE02LV0OvTcwfqhcSwVg4of3MLNUWPMArO6Aj8YXqyEVnPu8xTEMY2btKSq37mVAPuaEVASI4e3ptObmqcA==,
+        integrity: sha512-qYGWGuVpUTnZGu5P/CR4KLK4aIR8RrcVnmfZ2eRcj9q/I8VZCoC5yy9FtEvfNvnDp4MU17yhdJcvpQPIqhJS2Q==,
       }
     peerDependencies:
       "@volar/language-service": ~2.4.0
@@ -4584,10 +4327,23 @@ packages:
       }
     engines: { node: ">=14.0.0" }
 
+  vscode-jsonrpc@9.0.0:
+    resolution:
+      {
+        integrity: sha512-+VvMmQPJhtvJ+8O+zu2JKIRiLxXF8NW7krWgyMGeOHrp4Cn23T5hc0v2LknNeopDOB70wghHAds7mKtcZ0I4Sg==,
+      }
+    engines: { node: ">=14.0.0" }
+
   vscode-languageserver-protocol@3.17.5:
     resolution:
       {
         integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==,
+      }
+
+  vscode-languageserver-protocol@3.18.0:
+    resolution:
+      {
+        integrity: sha512-Zdz+kJ12Iz6tc11xfZyEo501bBATHXrCjmMfnaR3pMnf1CoqZBKIynba3P+/bi9VEdrMbNtAVKYpKhbODvqy+Q==,
       }
 
   vscode-languageserver-textdocument@1.0.12:
@@ -4600,6 +4356,12 @@ packages:
     resolution:
       {
         integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==,
+      }
+
+  vscode-languageserver-types@3.18.0:
+    resolution:
+      {
+        integrity: sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==,
       }
 
   vscode-languageserver@9.0.1:
@@ -4621,10 +4383,10 @@ packages:
         integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==,
       }
 
-  vue@3.5.30:
+  vue@3.5.38:
     resolution:
       {
-        integrity: sha512-hTHLc6VNZyzzEH/l7PFGjpcTvUgiaPK5mdLkbjrTeWSRcEfxFrv56g/XckIYlE9ckuobsdwqd5mk2g1sBkMewg==,
+        integrity: sha512-vAMKHfImQlYSy0C+PBue4s3ERZ2xGKfgZg5GXAsLInq1dyh2H78ILVP5sK0KPFPVW4kv+OGCIvBEondcjpZp7A==,
       }
     peerDependencies:
       typescript: "*"
@@ -4645,13 +4407,6 @@ packages:
       }
     engines: { node: ">=4" }
 
-  widest-line@5.0.0:
-    resolution:
-      {
-        integrity: sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==,
-      }
-    engines: { node: ">=18" }
-
   wrap-ansi@7.0.0:
     resolution:
       {
@@ -4659,18 +4414,18 @@ packages:
       }
     engines: { node: ">=10" }
 
-  wrap-ansi@9.0.2:
-    resolution:
-      {
-        integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==,
-      }
-    engines: { node: ">=18" }
-
   wrappy@1.0.2:
     resolution:
       {
         integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==,
       }
+
+  xml-naming@0.1.0:
+    resolution:
+      {
+        integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==,
+      }
+    engines: { node: ">=16.0.0" }
 
   xxhash-wasm@1.1.0:
     resolution:
@@ -4692,25 +4447,25 @@ packages:
       }
     engines: { node: ">=18" }
 
-  yaml-language-server@1.19.2:
+  yaml-language-server@1.23.0:
     resolution:
       {
-        integrity: sha512-9F3myNmJzUN/679jycdMxqtydPSDRAarSj3wPiF7pchEPnO9Dg07Oc+gIYLqXR4L+g+FSEVXXv2+mr54StLFOg==,
+        integrity: sha512-3qVyCOexLCWw06PQa5kRPwvMWMZ/eZeCRWUvgD6a0OkqL/4iCnxy2WumbWifa937Uo5xhyWJ0uxlU39ljhNh7A==,
       }
     hasBin: true
 
-  yaml@2.7.1:
+  yaml@2.8.3:
     resolution:
       {
-        integrity: sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==,
+        integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==,
       }
-    engines: { node: ">= 14" }
+    engines: { node: ">= 14.6" }
     hasBin: true
 
-  yaml@2.8.2:
+  yaml@2.9.0:
     resolution:
       {
-        integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==,
+        integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==,
       }
     engines: { node: ">= 14.6" }
     hasBin: true
@@ -4721,6 +4476,13 @@ packages:
         integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==,
       }
     engines: { node: ">=12" }
+
+  yargs-parser@22.0.0:
+    resolution:
+      {
+        integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==,
+      }
+    engines: { node: ^20.19.0 || ^22.12.0 || >=23 }
 
   yargs@17.7.2:
     resolution:
@@ -4736,41 +4498,16 @@ packages:
       }
     engines: { node: ">=12.20" }
 
-  yocto-spinner@0.2.3:
-    resolution:
-      {
-        integrity: sha512-sqBChb33loEnkoXte1bLg45bEBsOP9N1kzQh5JZNKj/0rik4zAPTNSAVPj3uQAdc6slYJ0Ksc403G2XgxsJQFQ==,
-      }
-    engines: { node: ">=18.19" }
-
-  yoctocolors@2.1.2:
-    resolution:
-      {
-        integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==,
-      }
-    engines: { node: ">=18" }
-
-  zod-to-json-schema@3.25.1:
-    resolution:
-      {
-        integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==,
-      }
-    peerDependencies:
-      zod: ^3.25 || ^4
-
-  zod-to-ts@1.2.0:
-    resolution:
-      {
-        integrity: sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA==,
-      }
-    peerDependencies:
-      typescript: ^4.9.4 || ^5.0.2
-      zod: ^3
-
   zod@3.25.76:
     resolution:
       {
         integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==,
+      }
+
+  zod@4.4.3:
+    resolution:
+      {
+        integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==,
       }
 
   zwitch@2.0.4:
@@ -4780,19 +4517,9 @@ packages:
       }
 
 snapshots:
-  "@ascorbic/feed-loader@2.0.1(astro@5.18.0(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2))":
+  "@astrojs/check@0.9.9(prettier-plugin-astro@0.14.1)(prettier@3.8.4)(typescript@5.9.3)":
     dependencies:
-      "@ascorbic/loader-utils": 1.0.2(astro@5.18.0(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2))
-      "@rowanmanning/feed-parser": 2.1.2
-      astro: 5.18.0(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2)
-
-  "@ascorbic/loader-utils@1.0.2(astro@5.18.0(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2))":
-    dependencies:
-      astro: 5.18.0(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2)
-
-  "@astrojs/check@0.9.6(prettier-plugin-astro@0.14.1)(prettier@3.8.1)(typescript@5.9.3)":
-    dependencies:
-      "@astrojs/language-server": 2.16.3(prettier-plugin-astro@0.14.1)(prettier@3.8.1)(typescript@5.9.3)
+      "@astrojs/language-server": 2.16.10(prettier-plugin-astro@0.14.1)(prettier@3.8.4)(typescript@5.9.3)
       chokidar: 4.0.3
       kleur: 4.1.5
       typescript: 5.9.3
@@ -4803,45 +4530,52 @@ snapshots:
 
   "@astrojs/compiler@2.13.1": {}
 
-  "@astrojs/internal-helpers@0.7.5": {}
+  "@astrojs/compiler@4.0.0": {}
 
-  "@astrojs/internal-helpers@0.7.6": {}
+  "@astrojs/internal-helpers@0.10.0":
+    dependencies:
+      "@types/hast": 3.0.4
+      "@types/mdast": 4.0.4
+      js-yaml: 4.2.0
+      picomatch: 4.0.4
+      retext-smartypants: 6.2.0
+      shiki: 4.2.0
+      smol-toml: 1.6.1
+      unified: 11.0.5
 
-  "@astrojs/language-server@2.16.3(prettier-plugin-astro@0.14.1)(prettier@3.8.1)(typescript@5.9.3)":
+  "@astrojs/language-server@2.16.10(prettier-plugin-astro@0.14.1)(prettier@3.8.4)(typescript@5.9.3)":
     dependencies:
       "@astrojs/compiler": 2.13.1
-      "@astrojs/yaml2ts": 0.2.2
+      "@astrojs/yaml2ts": 0.2.4
       "@jridgewell/sourcemap-codec": 1.5.5
       "@volar/kit": 2.4.28(typescript@5.9.3)
       "@volar/language-core": 2.4.28
       "@volar/language-server": 2.4.28
       "@volar/language-service": 2.4.28
       muggle-string: 0.4.1
-      tinyglobby: 0.2.15
-      volar-service-css: 0.0.68(@volar/language-service@2.4.28)
-      volar-service-emmet: 0.0.68(@volar/language-service@2.4.28)
-      volar-service-html: 0.0.68(@volar/language-service@2.4.28)
-      volar-service-prettier: 0.0.68(@volar/language-service@2.4.28)(prettier@3.8.1)
-      volar-service-typescript: 0.0.68(@volar/language-service@2.4.28)
-      volar-service-typescript-twoslash-queries: 0.0.68(@volar/language-service@2.4.28)
-      volar-service-yaml: 0.0.68(@volar/language-service@2.4.28)
+      tinyglobby: 0.2.17
+      volar-service-css: 0.0.70(@volar/language-service@2.4.28)
+      volar-service-emmet: 0.0.70(@volar/language-service@2.4.28)
+      volar-service-html: 0.0.70(@volar/language-service@2.4.28)
+      volar-service-prettier: 0.0.70(@volar/language-service@2.4.28)(prettier@3.8.4)
+      volar-service-typescript: 0.0.70(@volar/language-service@2.4.28)
+      volar-service-typescript-twoslash-queries: 0.0.70(@volar/language-service@2.4.28)
+      volar-service-yaml: 0.0.71(@volar/language-service@2.4.28)
       vscode-html-languageservice: 5.6.2
       vscode-uri: 3.1.0
     optionalDependencies:
-      prettier: 3.8.1
+      prettier: 3.8.4
       prettier-plugin-astro: 0.14.1
     transitivePeerDependencies:
       - typescript
 
-  "@astrojs/markdown-remark@6.3.10":
+  "@astrojs/markdown-remark@7.2.0":
     dependencies:
-      "@astrojs/internal-helpers": 0.7.5
-      "@astrojs/prism": 3.3.0
+      "@astrojs/internal-helpers": 0.10.0
+      "@astrojs/prism": 4.0.2
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.3
       hast-util-to-text: 4.0.2
-      import-meta-resolve: 4.2.0
-      js-yaml: 4.1.1
       mdast-util-definitions: 6.0.0
       rehype-raw: 7.0.0
       rehype-stringify: 10.0.1
@@ -4849,8 +4583,6 @@ snapshots:
       remark-parse: 11.0.0
       remark-rehype: 11.1.2
       remark-smartypants: 3.0.2
-      shiki: 3.23.0
-      smol-toml: 1.6.0
       unified: 11.0.5
       unist-util-remove-position: 5.0.0
       unist-util-visit: 5.1.0
@@ -4859,13 +4591,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@astrojs/mdx@4.3.13(astro@5.18.0(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2))":
+  "@astrojs/mdx@6.0.3(astro@6.4.8(@types/node@24.13.2)(rollup@4.62.0)(yaml@2.9.0))":
     dependencies:
-      "@astrojs/markdown-remark": 6.3.10
+      "@astrojs/internal-helpers": 0.10.0
+      "@astrojs/markdown-remark": 7.2.0
       "@mdx-js/mdx": 3.1.1
-      acorn: 8.16.0
-      astro: 5.18.0(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2)
-      es-module-lexer: 1.7.0
+      acorn: 8.17.0
+      astro: 6.4.8(@types/node@24.13.2)(rollup@4.62.0)(yaml@2.9.0)
+      es-module-lexer: 2.1.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
       piccolore: 0.1.3
@@ -4878,121 +4611,118 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@astrojs/node@9.5.5(astro@5.18.0(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2))":
+  "@astrojs/node@10.1.4(astro@6.4.8(@types/node@24.13.2)(rollup@4.62.0)(yaml@2.9.0))":
     dependencies:
-      "@astrojs/internal-helpers": 0.7.6
-      astro: 5.18.0(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2)
+      "@astrojs/internal-helpers": 0.10.0
+      astro: 6.4.8(@types/node@24.13.2)(rollup@4.62.0)(yaml@2.9.0)
       send: 1.2.1
       server-destroy: 1.0.1
     transitivePeerDependencies:
       - supports-color
 
-  "@astrojs/prism@3.3.0":
+  "@astrojs/prism@4.0.2":
     dependencies:
       prismjs: 1.30.0
 
-  "@astrojs/rss@4.0.15":
+  "@astrojs/rss@4.0.18":
     dependencies:
-      fast-xml-parser: 5.4.2
+      fast-xml-parser: 5.9.2
       piccolore: 0.1.3
+      zod: 4.4.3
 
-  "@astrojs/sitemap@3.7.0":
+  "@astrojs/sitemap@3.7.3":
     dependencies:
-      sitemap: 8.0.3
+      sitemap: 9.0.1
       stream-replace-string: 2.0.0
-      zod: 3.25.76
+      zod: 4.4.3
 
-  "@astrojs/telemetry@3.3.0":
+  "@astrojs/telemetry@3.3.2":
     dependencies:
       ci-info: 4.4.0
-      debug: 4.4.3
-      dlv: 1.1.3
       dset: 3.1.4
-      is-docker: 3.0.0
+      is-docker: 4.0.0
       is-wsl: 3.1.1
       which-pm-runs: 1.1.0
-    transitivePeerDependencies:
-      - supports-color
 
-  "@astrojs/yaml2ts@0.2.2":
+  "@astrojs/yaml2ts@0.2.4":
     dependencies:
-      yaml: 2.8.2
+      yaml: 2.9.0
 
-  "@atproto/api@0.17.7":
+  "@atproto/api@0.20.16":
     dependencies:
-      "@atproto/common-web": 0.4.18
-      "@atproto/lexicon": 0.5.2
-      "@atproto/syntax": 0.4.3
-      "@atproto/xrpc": 0.7.7
-      await-lock: 2.2.2
-      multiformats: 9.9.0
+      "@atproto/common-web": 0.5.1
+      "@atproto/lexicon": 0.7.2
+      "@atproto/syntax": 0.6.2
+      "@atproto/xrpc": 0.8.1
+      await-lock: 3.0.0
+      multiformats: 13.4.2
       tlds: 1.261.0
       zod: 3.25.76
 
-  "@atproto/common-web@0.4.18":
+  "@atproto/common-web@0.5.1":
     dependencies:
-      "@atproto/lex-data": 0.0.13
-      "@atproto/lex-json": 0.0.13
-      "@atproto/syntax": 0.5.0
+      "@atproto/lex-data": 0.1.2
+      "@atproto/lex-json": 0.1.1
+      "@atproto/syntax": 0.6.2
       zod: 3.25.76
 
-  "@atproto/lex-data@0.0.13":
+  "@atproto/lex-data@0.1.2":
     dependencies:
-      multiformats: 9.9.0
+      multiformats: 13.4.2
       tslib: 2.8.1
-      uint8arrays: 3.0.0
+      uint8arrays: 5.1.1
       unicode-segmenter: 0.14.5
 
-  "@atproto/lex-json@0.0.13":
+  "@atproto/lex-json@0.1.1":
     dependencies:
-      "@atproto/lex-data": 0.0.13
+      "@atproto/lex-data": 0.1.2
       tslib: 2.8.1
 
-  "@atproto/lexicon@0.5.2":
+  "@atproto/lexicon@0.7.2":
     dependencies:
-      "@atproto/common-web": 0.4.18
-      "@atproto/syntax": 0.4.3
+      "@atproto/common-web": 0.5.1
+      "@atproto/syntax": 0.6.2
+      multiformats: 13.4.2
+      zod: 3.25.76
+
+  "@atproto/syntax@0.6.2":
+    dependencies:
       iso-datestring-validator: 2.2.2
-      multiformats: 9.9.0
-      zod: 3.25.76
-
-  "@atproto/lexicon@0.6.2":
-    dependencies:
-      "@atproto/common-web": 0.4.18
-      "@atproto/syntax": 0.5.0
-      iso-datestring-validator: 2.2.2
-      multiformats: 9.9.0
-      zod: 3.25.76
-
-  "@atproto/syntax@0.4.3":
-    dependencies:
       tslib: 2.8.1
 
-  "@atproto/syntax@0.5.0":
+  "@atproto/xrpc@0.8.1":
     dependencies:
-      tslib: 2.8.1
-
-  "@atproto/xrpc@0.7.7":
-    dependencies:
-      "@atproto/lexicon": 0.6.2
+      "@atproto/lexicon": 0.7.2
       zod: 3.25.76
 
-  "@babel/helper-string-parser@7.27.1": {}
+  "@babel/helper-string-parser@7.29.7": {}
 
-  "@babel/helper-validator-identifier@7.28.5": {}
+  "@babel/helper-validator-identifier@7.29.7": {}
 
-  "@babel/parser@7.29.0":
+  "@babel/parser@7.29.7":
     dependencies:
-      "@babel/types": 7.29.0
+      "@babel/types": 7.29.7
 
-  "@babel/types@7.29.0":
+  "@babel/types@7.29.7":
     dependencies:
-      "@babel/helper-string-parser": 7.27.1
-      "@babel/helper-validator-identifier": 7.28.5
+      "@babel/helper-string-parser": 7.29.7
+      "@babel/helper-validator-identifier": 7.29.7
 
-  "@capsizecss/unpack@4.0.0":
+  "@capsizecss/unpack@4.0.1":
     dependencies:
-      fontkitten: 1.0.2
+      fontkitten: 1.0.3
+
+  "@clack/core@1.4.1":
+    dependencies:
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
+
+  "@clack/prompts@1.5.1":
+    dependencies:
+      "@clack/core": 1.4.1
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
 
   "@emmetio/abbreviation@2.3.3":
     dependencies:
@@ -5017,165 +4747,87 @@ snapshots:
 
   "@emmetio/stream-reader@2.2.0": {}
 
-  "@emnapi/runtime@1.8.1":
+  "@emnapi/runtime@1.11.1":
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  "@esbuild/aix-ppc64@0.25.12":
+  "@esbuild/aix-ppc64@0.28.1":
     optional: true
 
-  "@esbuild/aix-ppc64@0.27.3":
+  "@esbuild/android-arm64@0.28.1":
     optional: true
 
-  "@esbuild/android-arm64@0.25.12":
+  "@esbuild/android-arm@0.28.1":
     optional: true
 
-  "@esbuild/android-arm64@0.27.3":
+  "@esbuild/android-x64@0.28.1":
     optional: true
 
-  "@esbuild/android-arm@0.25.12":
+  "@esbuild/darwin-arm64@0.28.1":
     optional: true
 
-  "@esbuild/android-arm@0.27.3":
+  "@esbuild/darwin-x64@0.28.1":
     optional: true
 
-  "@esbuild/android-x64@0.25.12":
+  "@esbuild/freebsd-arm64@0.28.1":
     optional: true
 
-  "@esbuild/android-x64@0.27.3":
+  "@esbuild/freebsd-x64@0.28.1":
     optional: true
 
-  "@esbuild/darwin-arm64@0.25.12":
+  "@esbuild/linux-arm64@0.28.1":
     optional: true
 
-  "@esbuild/darwin-arm64@0.27.3":
+  "@esbuild/linux-arm@0.28.1":
     optional: true
 
-  "@esbuild/darwin-x64@0.25.12":
+  "@esbuild/linux-ia32@0.28.1":
     optional: true
 
-  "@esbuild/darwin-x64@0.27.3":
+  "@esbuild/linux-loong64@0.28.1":
     optional: true
 
-  "@esbuild/freebsd-arm64@0.25.12":
+  "@esbuild/linux-mips64el@0.28.1":
     optional: true
 
-  "@esbuild/freebsd-arm64@0.27.3":
+  "@esbuild/linux-ppc64@0.28.1":
     optional: true
 
-  "@esbuild/freebsd-x64@0.25.12":
+  "@esbuild/linux-riscv64@0.28.1":
     optional: true
 
-  "@esbuild/freebsd-x64@0.27.3":
+  "@esbuild/linux-s390x@0.28.1":
     optional: true
 
-  "@esbuild/linux-arm64@0.25.12":
+  "@esbuild/linux-x64@0.28.1":
     optional: true
 
-  "@esbuild/linux-arm64@0.27.3":
+  "@esbuild/netbsd-arm64@0.28.1":
     optional: true
 
-  "@esbuild/linux-arm@0.25.12":
+  "@esbuild/netbsd-x64@0.28.1":
     optional: true
 
-  "@esbuild/linux-arm@0.27.3":
+  "@esbuild/openbsd-arm64@0.28.1":
     optional: true
 
-  "@esbuild/linux-ia32@0.25.12":
+  "@esbuild/openbsd-x64@0.28.1":
     optional: true
 
-  "@esbuild/linux-ia32@0.27.3":
+  "@esbuild/openharmony-arm64@0.28.1":
     optional: true
 
-  "@esbuild/linux-loong64@0.25.12":
+  "@esbuild/sunos-x64@0.28.1":
     optional: true
 
-  "@esbuild/linux-loong64@0.27.3":
+  "@esbuild/win32-arm64@0.28.1":
     optional: true
 
-  "@esbuild/linux-mips64el@0.25.12":
+  "@esbuild/win32-ia32@0.28.1":
     optional: true
 
-  "@esbuild/linux-mips64el@0.27.3":
-    optional: true
-
-  "@esbuild/linux-ppc64@0.25.12":
-    optional: true
-
-  "@esbuild/linux-ppc64@0.27.3":
-    optional: true
-
-  "@esbuild/linux-riscv64@0.25.12":
-    optional: true
-
-  "@esbuild/linux-riscv64@0.27.3":
-    optional: true
-
-  "@esbuild/linux-s390x@0.25.12":
-    optional: true
-
-  "@esbuild/linux-s390x@0.27.3":
-    optional: true
-
-  "@esbuild/linux-x64@0.25.12":
-    optional: true
-
-  "@esbuild/linux-x64@0.27.3":
-    optional: true
-
-  "@esbuild/netbsd-arm64@0.25.12":
-    optional: true
-
-  "@esbuild/netbsd-arm64@0.27.3":
-    optional: true
-
-  "@esbuild/netbsd-x64@0.25.12":
-    optional: true
-
-  "@esbuild/netbsd-x64@0.27.3":
-    optional: true
-
-  "@esbuild/openbsd-arm64@0.25.12":
-    optional: true
-
-  "@esbuild/openbsd-arm64@0.27.3":
-    optional: true
-
-  "@esbuild/openbsd-x64@0.25.12":
-    optional: true
-
-  "@esbuild/openbsd-x64@0.27.3":
-    optional: true
-
-  "@esbuild/openharmony-arm64@0.25.12":
-    optional: true
-
-  "@esbuild/openharmony-arm64@0.27.3":
-    optional: true
-
-  "@esbuild/sunos-x64@0.25.12":
-    optional: true
-
-  "@esbuild/sunos-x64@0.27.3":
-    optional: true
-
-  "@esbuild/win32-arm64@0.25.12":
-    optional: true
-
-  "@esbuild/win32-arm64@0.27.3":
-    optional: true
-
-  "@esbuild/win32-ia32@0.25.12":
-    optional: true
-
-  "@esbuild/win32-ia32@0.27.3":
-    optional: true
-
-  "@esbuild/win32-x64@0.25.12":
-    optional: true
-
-  "@esbuild/win32-x64@0.27.3":
+  "@esbuild/win32-x64@0.28.1":
     optional: true
 
   "@img/colour@1.1.0":
@@ -5263,7 +4915,7 @@ snapshots:
 
   "@img/sharp-wasm32@0.34.5":
     dependencies:
-      "@emnapi/runtime": 1.8.1
+      "@emnapi/runtime": 1.11.1
     optional: true
 
   "@img/sharp-win32-arm64@0.34.5":
@@ -5283,11 +4935,11 @@ snapshots:
 
   "@mdx-js/mdx@3.1.1":
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
       "@types/estree-jsx": 1.0.5
       "@types/hast": 3.0.4
-      "@types/mdx": 2.0.13
-      acorn: 8.16.0
+      "@types/mdx": 2.0.14
+      acorn: 8.17.0
       collapse-white-space: 2.1.0
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
@@ -5296,7 +4948,7 @@ snapshots:
       hast-util-to-jsx-runtime: 2.3.6
       markdown-extensions: 2.0.0
       recma-build-jsx: 1.0.0
-      recma-jsx: 1.0.1(acorn@8.16.0)
+      recma-jsx: 1.0.1(acorn@8.17.0)
       recma-stringify: 1.0.0
       rehype-recma: 1.0.0
       remark-mdx: 3.1.1
@@ -5310,6 +4962,8 @@ snapshots:
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
+
+  "@nodable/entities@2.2.0": {}
 
   "@octokit/app@16.1.2":
     dependencies:
@@ -5325,10 +4979,10 @@ snapshots:
     dependencies:
       "@octokit/auth-oauth-app": 9.0.3
       "@octokit/auth-oauth-user": 6.0.2
-      "@octokit/request": 10.0.8
+      "@octokit/request": 10.0.10
       "@octokit/request-error": 7.1.0
       "@octokit/types": 16.0.0
-      toad-cache: 3.7.0
+      toad-cache: 3.7.1
       universal-github-app-jwt: 2.2.2
       universal-user-agent: 7.0.3
 
@@ -5336,14 +4990,14 @@ snapshots:
     dependencies:
       "@octokit/auth-oauth-device": 8.0.3
       "@octokit/auth-oauth-user": 6.0.2
-      "@octokit/request": 10.0.8
+      "@octokit/request": 10.0.10
       "@octokit/types": 16.0.0
       universal-user-agent: 7.0.3
 
   "@octokit/auth-oauth-device@8.0.3":
     dependencies:
       "@octokit/oauth-methods": 6.0.2
-      "@octokit/request": 10.0.8
+      "@octokit/request": 10.0.10
       "@octokit/types": 16.0.0
       universal-user-agent: 7.0.3
 
@@ -5351,7 +5005,7 @@ snapshots:
     dependencies:
       "@octokit/auth-oauth-device": 8.0.3
       "@octokit/oauth-methods": 6.0.2
-      "@octokit/request": 10.0.8
+      "@octokit/request": 10.0.10
       "@octokit/types": 16.0.0
       universal-user-agent: 7.0.3
 
@@ -5366,7 +5020,7 @@ snapshots:
     dependencies:
       "@octokit/auth-token": 6.0.0
       "@octokit/graphql": 9.0.3
-      "@octokit/request": 10.0.8
+      "@octokit/request": 10.0.10
       "@octokit/request-error": 7.1.0
       "@octokit/types": 16.0.0
       before-after-hook: 4.0.0
@@ -5379,7 +5033,7 @@ snapshots:
 
   "@octokit/graphql@9.0.3":
     dependencies:
-      "@octokit/request": 10.0.8
+      "@octokit/request": 10.0.10
       "@octokit/types": 16.0.0
       universal-user-agent: 7.0.3
 
@@ -5391,7 +5045,7 @@ snapshots:
       "@octokit/core": 7.0.6
       "@octokit/oauth-authorization-url": 8.0.0
       "@octokit/oauth-methods": 6.0.2
-      "@types/aws-lambda": 8.10.161
+      "@types/aws-lambda": 8.10.162
       universal-user-agent: 7.0.3
 
   "@octokit/oauth-authorization-url@8.0.0": {}
@@ -5399,7 +5053,7 @@ snapshots:
   "@octokit/oauth-methods@6.0.2":
     dependencies:
       "@octokit/oauth-authorization-url": 8.0.0
-      "@octokit/request": 10.0.8
+      "@octokit/request": 10.0.10
       "@octokit/request-error": 7.1.0
       "@octokit/types": 16.0.0
 
@@ -5438,13 +5092,13 @@ snapshots:
     dependencies:
       "@octokit/types": 16.0.0
 
-  "@octokit/request@10.0.8":
+  "@octokit/request@10.0.10":
     dependencies:
       "@octokit/endpoint": 11.0.3
       "@octokit/request-error": 7.1.0
       "@octokit/types": 16.0.0
-      fast-content-type-parse: 3.0.0
-      json-with-bigint: 3.5.7
+      content-type: 2.0.0
+      json-with-bigint: 3.5.8
       universal-user-agent: 7.0.3
 
   "@octokit/types@16.0.0":
@@ -5461,128 +5115,135 @@ snapshots:
 
   "@oslojs/encoding@1.1.0": {}
 
-  "@rollup/pluginutils@5.3.0(rollup@4.59.0)":
+  "@rollup/pluginutils@5.4.0(rollup@4.62.0)":
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
       estree-walker: 2.0.2
-      picomatch: 4.0.3
+      picomatch: 4.0.4
     optionalDependencies:
-      rollup: 4.59.0
+      rollup: 4.62.0
 
-  "@rollup/rollup-android-arm-eabi@4.59.0":
+  "@rollup/rollup-android-arm-eabi@4.62.0":
     optional: true
 
-  "@rollup/rollup-android-arm64@4.59.0":
+  "@rollup/rollup-android-arm64@4.62.0":
     optional: true
 
-  "@rollup/rollup-darwin-arm64@4.59.0":
+  "@rollup/rollup-darwin-arm64@4.62.0":
     optional: true
 
-  "@rollup/rollup-darwin-x64@4.59.0":
+  "@rollup/rollup-darwin-x64@4.62.0":
     optional: true
 
-  "@rollup/rollup-freebsd-arm64@4.59.0":
+  "@rollup/rollup-freebsd-arm64@4.62.0":
     optional: true
 
-  "@rollup/rollup-freebsd-x64@4.59.0":
+  "@rollup/rollup-freebsd-x64@4.62.0":
     optional: true
 
-  "@rollup/rollup-linux-arm-gnueabihf@4.59.0":
+  "@rollup/rollup-linux-arm-gnueabihf@4.62.0":
     optional: true
 
-  "@rollup/rollup-linux-arm-musleabihf@4.59.0":
+  "@rollup/rollup-linux-arm-musleabihf@4.62.0":
     optional: true
 
-  "@rollup/rollup-linux-arm64-gnu@4.59.0":
+  "@rollup/rollup-linux-arm64-gnu@4.62.0":
     optional: true
 
-  "@rollup/rollup-linux-arm64-musl@4.59.0":
+  "@rollup/rollup-linux-arm64-musl@4.62.0":
     optional: true
 
-  "@rollup/rollup-linux-loong64-gnu@4.59.0":
+  "@rollup/rollup-linux-loong64-gnu@4.62.0":
     optional: true
 
-  "@rollup/rollup-linux-loong64-musl@4.59.0":
+  "@rollup/rollup-linux-loong64-musl@4.62.0":
     optional: true
 
-  "@rollup/rollup-linux-ppc64-gnu@4.59.0":
+  "@rollup/rollup-linux-ppc64-gnu@4.62.0":
     optional: true
 
-  "@rollup/rollup-linux-ppc64-musl@4.59.0":
+  "@rollup/rollup-linux-ppc64-musl@4.62.0":
     optional: true
 
-  "@rollup/rollup-linux-riscv64-gnu@4.59.0":
+  "@rollup/rollup-linux-riscv64-gnu@4.62.0":
     optional: true
 
-  "@rollup/rollup-linux-riscv64-musl@4.59.0":
+  "@rollup/rollup-linux-riscv64-musl@4.62.0":
     optional: true
 
-  "@rollup/rollup-linux-s390x-gnu@4.59.0":
+  "@rollup/rollup-linux-s390x-gnu@4.62.0":
     optional: true
 
-  "@rollup/rollup-linux-x64-gnu@4.59.0":
+  "@rollup/rollup-linux-x64-gnu@4.62.0":
     optional: true
 
-  "@rollup/rollup-linux-x64-musl@4.59.0":
+  "@rollup/rollup-linux-x64-musl@4.62.0":
     optional: true
 
-  "@rollup/rollup-openbsd-x64@4.59.0":
+  "@rollup/rollup-openbsd-x64@4.62.0":
     optional: true
 
-  "@rollup/rollup-openharmony-arm64@4.59.0":
+  "@rollup/rollup-openharmony-arm64@4.62.0":
     optional: true
 
-  "@rollup/rollup-win32-arm64-msvc@4.59.0":
+  "@rollup/rollup-win32-arm64-msvc@4.62.0":
     optional: true
 
-  "@rollup/rollup-win32-ia32-msvc@4.59.0":
+  "@rollup/rollup-win32-ia32-msvc@4.62.0":
     optional: true
 
-  "@rollup/rollup-win32-x64-gnu@4.59.0":
+  "@rollup/rollup-win32-x64-gnu@4.62.0":
     optional: true
 
-  "@rollup/rollup-win32-x64-msvc@4.59.0":
+  "@rollup/rollup-win32-x64-msvc@4.62.0":
     optional: true
 
-  "@rowanmanning/feed-parser@2.1.2":
+  "@rowanmanning/feed-parser@2.1.3":
     dependencies:
-      fast-xml-parser: 5.4.2
+      fast-xml-parser: 5.9.2
       html-entities: 2.6.0
 
-  "@shikijs/core@3.23.0":
+  "@shikijs/core@4.2.0":
     dependencies:
-      "@shikijs/types": 3.23.0
+      "@shikijs/primitive": 4.2.0
+      "@shikijs/types": 4.2.0
       "@shikijs/vscode-textmate": 10.0.2
       "@types/hast": 3.0.4
       hast-util-to-html: 9.0.5
 
-  "@shikijs/engine-javascript@3.23.0":
+  "@shikijs/engine-javascript@4.2.0":
     dependencies:
-      "@shikijs/types": 3.23.0
+      "@shikijs/types": 4.2.0
       "@shikijs/vscode-textmate": 10.0.2
-      oniguruma-to-es: 4.3.4
+      oniguruma-to-es: 4.3.6
 
-  "@shikijs/engine-oniguruma@3.23.0":
+  "@shikijs/engine-oniguruma@4.2.0":
     dependencies:
-      "@shikijs/types": 3.23.0
+      "@shikijs/types": 4.2.0
       "@shikijs/vscode-textmate": 10.0.2
 
-  "@shikijs/langs@3.23.0":
+  "@shikijs/langs@4.2.0":
     dependencies:
-      "@shikijs/types": 3.23.0
+      "@shikijs/types": 4.2.0
 
-  "@shikijs/themes@3.23.0":
+  "@shikijs/primitive@4.2.0":
     dependencies:
-      "@shikijs/types": 3.23.0
+      "@shikijs/types": 4.2.0
+      "@shikijs/vscode-textmate": 10.0.2
+      "@types/hast": 3.0.4
 
-  "@shikijs/types@3.23.0":
+  "@shikijs/themes@4.2.0":
+    dependencies:
+      "@shikijs/types": 4.2.0
+
+  "@shikijs/types@4.2.0":
     dependencies:
       "@shikijs/vscode-textmate": 10.0.2
       "@types/hast": 3.0.4
 
   "@shikijs/vscode-textmate@10.0.2": {}
 
-  "@types/aws-lambda@8.10.161": {}
+  "@types/aws-lambda@8.10.162": {}
 
   "@types/debug@4.1.12":
     dependencies:
@@ -5594,6 +5255,8 @@ snapshots:
 
   "@types/estree@1.0.8": {}
 
+  "@types/estree@1.0.9": {}
+
   "@types/hast@3.0.4":
     dependencies:
       "@types/unist": 3.0.3
@@ -5604,7 +5267,7 @@ snapshots:
     dependencies:
       "@types/unist": 3.0.3
 
-  "@types/mdx@2.0.13": {}
+  "@types/mdx@2.0.14": {}
 
   "@types/ms@2.1.0": {}
 
@@ -5612,11 +5275,13 @@ snapshots:
     dependencies:
       "@types/unist": 3.0.3
 
-  "@types/node@17.0.45": {}
+  "@types/node@24.13.2":
+    dependencies:
+      undici-types: 7.18.2
 
   "@types/sax@1.2.7":
     dependencies:
-      "@types/node": 17.0.45
+      "@types/node": 24.13.2
 
   "@types/unist@2.0.11": {}
 
@@ -5624,7 +5289,7 @@ snapshots:
 
   "@types/web-bluetooth@0.0.21": {}
 
-  "@ungap/structured-clone@1.3.0": {}
+  "@ungap/structured-clone@1.3.1": {}
 
   "@volar/kit@2.4.28(typescript@5.9.3)":
     dependencies:
@@ -5647,14 +5312,14 @@ snapshots:
       path-browserify: 1.0.1
       request-light: 0.7.0
       vscode-languageserver: 9.0.1
-      vscode-languageserver-protocol: 3.17.5
+      vscode-languageserver-protocol: 3.18.0
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
 
   "@volar/language-service@2.4.28":
     dependencies:
       "@volar/language-core": 2.4.28
-      vscode-languageserver-protocol: 3.17.5
+      vscode-languageserver-protocol: 3.18.0
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
 
@@ -5671,89 +5336,89 @@ snapshots:
       emmet: 2.4.11
       jsonc-parser: 2.3.1
       vscode-languageserver-textdocument: 1.0.12
-      vscode-languageserver-types: 3.17.5
+      vscode-languageserver-types: 3.18.0
       vscode-uri: 3.1.0
 
   "@vscode/l10n@0.0.18": {}
 
-  "@vue/compiler-core@3.5.30":
+  "@vue/compiler-core@3.5.38":
     dependencies:
-      "@babel/parser": 7.29.0
-      "@vue/shared": 3.5.30
+      "@babel/parser": 7.29.7
+      "@vue/shared": 3.5.38
       entities: 7.0.1
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
-  "@vue/compiler-dom@3.5.30":
+  "@vue/compiler-dom@3.5.38":
     dependencies:
-      "@vue/compiler-core": 3.5.30
-      "@vue/shared": 3.5.30
+      "@vue/compiler-core": 3.5.38
+      "@vue/shared": 3.5.38
 
-  "@vue/compiler-sfc@3.5.30":
+  "@vue/compiler-sfc@3.5.38":
     dependencies:
-      "@babel/parser": 7.29.0
-      "@vue/compiler-core": 3.5.30
-      "@vue/compiler-dom": 3.5.30
-      "@vue/compiler-ssr": 3.5.30
-      "@vue/shared": 3.5.30
+      "@babel/parser": 7.29.7
+      "@vue/compiler-core": 3.5.38
+      "@vue/compiler-dom": 3.5.38
+      "@vue/compiler-ssr": 3.5.38
+      "@vue/shared": 3.5.38
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.8
+      postcss: 8.5.15
       source-map-js: 1.2.1
 
-  "@vue/compiler-ssr@3.5.30":
+  "@vue/compiler-ssr@3.5.38":
     dependencies:
-      "@vue/compiler-dom": 3.5.30
-      "@vue/shared": 3.5.30
+      "@vue/compiler-dom": 3.5.38
+      "@vue/shared": 3.5.38
 
-  "@vue/reactivity@3.5.30":
+  "@vue/reactivity@3.5.38":
     dependencies:
-      "@vue/shared": 3.5.30
+      "@vue/shared": 3.5.38
 
-  "@vue/runtime-core@3.5.30":
+  "@vue/runtime-core@3.5.38":
     dependencies:
-      "@vue/reactivity": 3.5.30
-      "@vue/shared": 3.5.30
+      "@vue/reactivity": 3.5.38
+      "@vue/shared": 3.5.38
 
-  "@vue/runtime-dom@3.5.30":
+  "@vue/runtime-dom@3.5.38":
     dependencies:
-      "@vue/reactivity": 3.5.30
-      "@vue/runtime-core": 3.5.30
-      "@vue/shared": 3.5.30
+      "@vue/reactivity": 3.5.38
+      "@vue/runtime-core": 3.5.38
+      "@vue/shared": 3.5.38
       csstype: 3.2.3
 
-  "@vue/server-renderer@3.5.30(vue@3.5.30(typescript@5.9.3))":
+  "@vue/server-renderer@3.5.38(vue@3.5.38(typescript@5.9.3))":
     dependencies:
-      "@vue/compiler-ssr": 3.5.30
-      "@vue/shared": 3.5.30
-      vue: 3.5.30(typescript@5.9.3)
+      "@vue/compiler-ssr": 3.5.38
+      "@vue/shared": 3.5.38
+      vue: 3.5.38(typescript@5.9.3)
 
-  "@vue/shared@3.5.30": {}
+  "@vue/shared@3.5.38": {}
 
-  "@vueuse/core@14.2.1(vue@3.5.30(typescript@5.9.3))":
+  "@vueuse/core@14.3.0(vue@3.5.38(typescript@5.9.3))":
     dependencies:
       "@types/web-bluetooth": 0.0.21
-      "@vueuse/metadata": 14.2.1
-      "@vueuse/shared": 14.2.1(vue@3.5.30(typescript@5.9.3))
-      vue: 3.5.30(typescript@5.9.3)
+      "@vueuse/metadata": 14.3.0
+      "@vueuse/shared": 14.3.0(vue@3.5.38(typescript@5.9.3))
+      vue: 3.5.38(typescript@5.9.3)
 
-  "@vueuse/metadata@14.2.1": {}
+  "@vueuse/metadata@14.3.0": {}
 
-  "@vueuse/shared@14.2.1(vue@3.5.30(typescript@5.9.3))":
+  "@vueuse/shared@14.3.0(vue@3.5.38(typescript@5.9.3))":
     dependencies:
-      vue: 3.5.30(typescript@5.9.3)
+      vue: 3.5.38(typescript@5.9.3)
 
-  "@waline/api@1.1.0": {}
+  "@waline/api@1.1.2": {}
 
-  "@waline/client@3.13.0(typescript@5.9.3)":
+  "@waline/client@3.15.2(typescript@5.9.3)":
     dependencies:
-      "@vueuse/core": 14.2.1(vue@3.5.30(typescript@5.9.3))
-      "@waline/api": 1.1.0
+      "@vueuse/core": 14.3.0(vue@3.5.38(typescript@5.9.3))
+      "@waline/api": 1.1.2
       autosize: 6.0.1
-      marked: 17.0.4
-      marked-highlight: 2.2.3(marked@17.0.4)
+      marked: 18.0.5
+      marked-highlight: 2.2.4(marked@18.0.5)
       recaptcha-v3: 1.11.3
-      vue: 3.5.30(typescript@5.9.3)
+      vue: 3.5.38(typescript@5.9.3)
     transitivePeerDependencies:
       - typescript
 
@@ -5761,37 +5426,41 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
+  acorn-jsx@5.3.2(acorn@8.17.0):
+    dependencies:
+      acorn: 8.17.0
+
   acorn@8.16.0: {}
 
-  ajv-draft-04@1.0.0(ajv@8.18.0):
-    optionalDependencies:
-      ajv: 8.18.0
+  acorn@8.17.0: {}
 
-  ajv@8.18.0:
+  ajv-draft-04@1.0.0(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv-i18n@4.2.0(ajv@8.20.0):
+    dependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  ansi-align@3.0.1:
-    dependencies:
-      string-width: 4.2.3
-
   ansi-regex@5.0.1: {}
-
-  ansi-regex@6.2.2: {}
 
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
 
-  ansi-styles@6.2.3: {}
-
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 2.3.1
+      picomatch: 2.3.2
+
+  anynum@1.0.0: {}
 
   arg@5.0.2: {}
 
@@ -5803,19 +5472,19 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-auto-import@0.5.1(astro@5.18.0(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2)):
+  astro-auto-import@0.5.1(astro@6.4.8(@types/node@24.13.2)(rollup@4.62.0)(yaml@2.9.0)):
     dependencies:
       acorn: 8.16.0
-      astro: 5.18.0(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2)
+      astro: 6.4.8(@types/node@24.13.2)(rollup@4.62.0)(yaml@2.9.0)
 
-  astro-loader-bluesky-posts@1.2.3(astro@5.18.0(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2)):
+  astro-loader-bluesky-posts@1.2.4(astro@6.4.8(@types/node@24.13.2)(rollup@4.62.0)(yaml@2.9.0)):
     dependencies:
-      "@atproto/api": 0.17.7
-      astro: 5.18.0(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2)
+      "@atproto/api": 0.20.16
+      astro: 6.4.8(@types/node@24.13.2)(rollup@4.62.0)(yaml@2.9.0)
 
-  astro-loader-github-prs@1.3.1(astro@5.18.0(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2)):
+  astro-loader-github-prs@2.0.0(astro@6.4.8(@types/node@24.13.2)(rollup@4.62.0)(yaml@2.9.0)):
     dependencies:
-      astro: 5.18.0(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2)
+      astro: 6.4.8(@types/node@24.13.2)(rollup@4.62.0)(yaml@2.9.0)
       octokit: 5.0.5
 
   astro-robots-txt@1.0.0:
@@ -5823,71 +5492,63 @@ snapshots:
       valid-filename: 4.0.0
       zod: 3.25.76
 
-  astro@5.18.0(rollup@4.59.0)(typescript@5.9.3)(yaml@2.8.2):
+  astro@6.4.8(@types/node@24.13.2)(rollup@4.62.0)(yaml@2.9.0):
     dependencies:
-      "@astrojs/compiler": 2.13.1
-      "@astrojs/internal-helpers": 0.7.5
-      "@astrojs/markdown-remark": 6.3.10
-      "@astrojs/telemetry": 3.3.0
-      "@capsizecss/unpack": 4.0.0
+      "@astrojs/compiler": 4.0.0
+      "@astrojs/internal-helpers": 0.10.0
+      "@astrojs/markdown-remark": 7.2.0
+      "@astrojs/telemetry": 3.3.2
+      "@capsizecss/unpack": 4.0.1
+      "@clack/prompts": 1.5.1
       "@oslojs/encoding": 1.1.0
-      "@rollup/pluginutils": 5.3.0(rollup@4.59.0)
-      acorn: 8.16.0
+      "@rollup/pluginutils": 5.4.0(rollup@4.62.0)
       aria-query: 5.3.2
       axobject-query: 4.1.0
-      boxen: 8.0.1
       ci-info: 4.4.0
       clsx: 2.1.1
-      common-ancestor-path: 1.0.1
+      common-ancestor-path: 2.0.0
       cookie: 1.1.1
-      cssesc: 3.0.0
-      debug: 4.4.3
-      deterministic-object-hash: 2.0.2
-      devalue: 5.6.3
-      diff: 8.0.3
-      dlv: 1.1.3
+      devalue: 5.8.1
+      diff: 8.0.4
       dset: 3.1.4
-      es-module-lexer: 1.7.0
-      esbuild: 0.27.3
-      estree-walker: 3.0.3
+      es-module-lexer: 2.1.0
+      esbuild: 0.28.1
       flattie: 1.1.1
       fontace: 0.4.1
+      get-tsconfig: 5.0.0-beta.4
       github-slugger: 2.0.0
       html-escaper: 3.0.3
       http-cache-semantics: 4.2.0
-      import-meta-resolve: 4.2.0
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
+      jsonc-parser: 3.3.1
       magic-string: 0.30.21
-      magicast: 0.5.2
+      magicast: 0.5.3
       mrmime: 2.0.1
       neotraverse: 0.6.18
-      p-limit: 6.2.0
-      p-queue: 8.1.1
+      obug: 2.1.3
+      p-limit: 7.3.0
+      p-queue: 9.3.0
       package-manager-detector: 1.6.0
       piccolore: 0.1.3
-      picomatch: 4.0.3
-      prompts: 2.4.2
+      picomatch: 4.0.4
       rehype: 13.0.2
-      semver: 7.7.4
-      shiki: 3.23.0
-      smol-toml: 1.6.0
-      svgo: 4.0.0
-      tinyexec: 1.0.2
-      tinyglobby: 0.2.15
-      tsconfck: 3.1.6(typescript@5.9.3)
+      semver: 7.8.4
+      shiki: 4.2.0
+      smol-toml: 1.6.1
+      svgo: 4.0.1
+      tinyclip: 0.1.14
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
       ultrahtml: 1.6.0
       unifont: 0.7.4
       unist-util-visit: 5.1.0
-      unstorage: 1.17.4
+      unstorage: 1.17.5
       vfile: 6.0.3
-      vite: 6.4.1(yaml@2.8.2)
-      vitefu: 1.1.2(vite@6.4.1(yaml@2.8.2))
+      vite: 7.3.5(@types/node@24.13.2)(yaml@2.9.0)
+      vitefu: 1.1.3(vite@7.3.5(@types/node@24.13.2)(yaml@2.9.0))
       xxhash-wasm: 1.1.0
-      yargs-parser: 21.1.1
-      yocto-spinner: 0.2.3
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.1(zod@3.25.76)
-      zod-to-ts: 1.2.0(typescript@5.9.3)(zod@3.25.76)
+      yargs-parser: 22.0.0
+      zod: 4.4.3
     optionalDependencies:
       sharp: 0.34.5
     transitivePeerDependencies:
@@ -5921,19 +5582,16 @@ snapshots:
       - supports-color
       - terser
       - tsx
-      - typescript
       - uploadthing
       - yaml
 
   autosize@6.0.1: {}
 
-  await-lock@2.2.2: {}
+  await-lock@3.0.0: {}
 
   axobject-query@4.1.0: {}
 
   bail@2.0.2: {}
-
-  base-64@1.0.0: {}
 
   base64-js@1.5.1: {}
 
@@ -5958,17 +5616,6 @@ snapshots:
 
   bottleneck@2.19.5: {}
 
-  boxen@8.0.1:
-    dependencies:
-      ansi-align: 3.0.1
-      camelcase: 8.0.0
-      chalk: 5.6.2
-      cli-boxes: 3.0.0
-      string-width: 7.2.0
-      type-fest: 4.41.0
-      widest-line: 5.0.0
-      wrap-ansi: 9.0.2
-
   bson@7.2.0: {}
 
   buffer@5.7.1:
@@ -5976,11 +5623,7 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  camelcase@8.0.0: {}
-
   ccount@2.0.1: {}
-
-  chalk@5.6.2: {}
 
   character-entities-html4@2.1.0: {}
 
@@ -6004,8 +5647,6 @@ snapshots:
 
   ci-info@4.4.0: {}
 
-  cli-boxes@3.0.0: {}
-
   cliui@8.0.1:
     dependencies:
       string-width: 4.2.3
@@ -6028,9 +5669,11 @@ snapshots:
 
   commander@8.3.0: {}
 
-  common-ancestor-path@1.0.1: {}
+  common-ancestor-path@2.0.0: {}
 
-  cookie-es@1.2.2: {}
+  content-type@2.0.0: {}
+
+  cookie-es@1.2.3: {}
 
   cookie@1.1.1: {}
 
@@ -6051,14 +5694,12 @@ snapshots:
       mdn-data: 2.0.28
       source-map-js: 1.2.1
 
-  css-tree@3.1.0:
+  css-tree@3.2.1:
     dependencies:
-      mdn-data: 2.12.2
+      mdn-data: 2.27.1
       source-map-js: 1.2.1
 
   css-what@6.2.2: {}
-
-  cssesc@3.0.0: {}
 
   csso@5.0.5:
     dependencies:
@@ -6080,7 +5721,7 @@ snapshots:
 
   deep-extend@0.6.0: {}
 
-  defu@6.1.4: {}
+  defu@6.1.7: {}
 
   depd@2.0.0: {}
 
@@ -6090,19 +5731,13 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
-  deterministic-object-hash@2.0.2:
-    dependencies:
-      base-64: 1.0.0
-
-  devalue@5.6.3: {}
+  devalue@5.8.1: {}
 
   devlop@1.1.0:
     dependencies:
       dequal: 2.0.3
 
-  diff@8.0.3: {}
-
-  dlv@1.1.3: {}
+  diff@8.0.4: {}
 
   dom-serializer@2.0.0:
     dependencies:
@@ -6131,8 +5766,6 @@ snapshots:
       "@emmetio/abbreviation": 2.3.3
       "@emmetio/css-abbreviation": 2.1.8
 
-  emoji-regex@10.6.0: {}
-
   emoji-regex@8.0.0: {}
 
   encodeurl@2.0.0: {}
@@ -6147,7 +5780,7 @@ snapshots:
 
   entities@7.0.1: {}
 
-  es-module-lexer@1.7.0: {}
+  es-module-lexer@2.1.0: {}
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -6159,67 +5792,38 @@ snapshots:
   esast-util-from-js@2.0.1:
     dependencies:
       "@types/estree-jsx": 1.0.5
-      acorn: 8.16.0
+      acorn: 8.17.0
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
 
-  esbuild@0.25.12:
+  esbuild@0.28.1:
     optionalDependencies:
-      "@esbuild/aix-ppc64": 0.25.12
-      "@esbuild/android-arm": 0.25.12
-      "@esbuild/android-arm64": 0.25.12
-      "@esbuild/android-x64": 0.25.12
-      "@esbuild/darwin-arm64": 0.25.12
-      "@esbuild/darwin-x64": 0.25.12
-      "@esbuild/freebsd-arm64": 0.25.12
-      "@esbuild/freebsd-x64": 0.25.12
-      "@esbuild/linux-arm": 0.25.12
-      "@esbuild/linux-arm64": 0.25.12
-      "@esbuild/linux-ia32": 0.25.12
-      "@esbuild/linux-loong64": 0.25.12
-      "@esbuild/linux-mips64el": 0.25.12
-      "@esbuild/linux-ppc64": 0.25.12
-      "@esbuild/linux-riscv64": 0.25.12
-      "@esbuild/linux-s390x": 0.25.12
-      "@esbuild/linux-x64": 0.25.12
-      "@esbuild/netbsd-arm64": 0.25.12
-      "@esbuild/netbsd-x64": 0.25.12
-      "@esbuild/openbsd-arm64": 0.25.12
-      "@esbuild/openbsd-x64": 0.25.12
-      "@esbuild/openharmony-arm64": 0.25.12
-      "@esbuild/sunos-x64": 0.25.12
-      "@esbuild/win32-arm64": 0.25.12
-      "@esbuild/win32-ia32": 0.25.12
-      "@esbuild/win32-x64": 0.25.12
-
-  esbuild@0.27.3:
-    optionalDependencies:
-      "@esbuild/aix-ppc64": 0.27.3
-      "@esbuild/android-arm": 0.27.3
-      "@esbuild/android-arm64": 0.27.3
-      "@esbuild/android-x64": 0.27.3
-      "@esbuild/darwin-arm64": 0.27.3
-      "@esbuild/darwin-x64": 0.27.3
-      "@esbuild/freebsd-arm64": 0.27.3
-      "@esbuild/freebsd-x64": 0.27.3
-      "@esbuild/linux-arm": 0.27.3
-      "@esbuild/linux-arm64": 0.27.3
-      "@esbuild/linux-ia32": 0.27.3
-      "@esbuild/linux-loong64": 0.27.3
-      "@esbuild/linux-mips64el": 0.27.3
-      "@esbuild/linux-ppc64": 0.27.3
-      "@esbuild/linux-riscv64": 0.27.3
-      "@esbuild/linux-s390x": 0.27.3
-      "@esbuild/linux-x64": 0.27.3
-      "@esbuild/netbsd-arm64": 0.27.3
-      "@esbuild/netbsd-x64": 0.27.3
-      "@esbuild/openbsd-arm64": 0.27.3
-      "@esbuild/openbsd-x64": 0.27.3
-      "@esbuild/openharmony-arm64": 0.27.3
-      "@esbuild/sunos-x64": 0.27.3
-      "@esbuild/win32-arm64": 0.27.3
-      "@esbuild/win32-ia32": 0.27.3
-      "@esbuild/win32-x64": 0.27.3
+      "@esbuild/aix-ppc64": 0.28.1
+      "@esbuild/android-arm": 0.28.1
+      "@esbuild/android-arm64": 0.28.1
+      "@esbuild/android-x64": 0.28.1
+      "@esbuild/darwin-arm64": 0.28.1
+      "@esbuild/darwin-x64": 0.28.1
+      "@esbuild/freebsd-arm64": 0.28.1
+      "@esbuild/freebsd-x64": 0.28.1
+      "@esbuild/linux-arm": 0.28.1
+      "@esbuild/linux-arm64": 0.28.1
+      "@esbuild/linux-ia32": 0.28.1
+      "@esbuild/linux-loong64": 0.28.1
+      "@esbuild/linux-mips64el": 0.28.1
+      "@esbuild/linux-ppc64": 0.28.1
+      "@esbuild/linux-riscv64": 0.28.1
+      "@esbuild/linux-s390x": 0.28.1
+      "@esbuild/linux-x64": 0.28.1
+      "@esbuild/netbsd-arm64": 0.28.1
+      "@esbuild/netbsd-x64": 0.28.1
+      "@esbuild/openbsd-arm64": 0.28.1
+      "@esbuild/openbsd-x64": 0.28.1
+      "@esbuild/openharmony-arm64": 0.28.1
+      "@esbuild/sunos-x64": 0.28.1
+      "@esbuild/win32-arm64": 0.28.1
+      "@esbuild/win32-ia32": 0.28.1
+      "@esbuild/win32-x64": 0.28.1
 
   escalade@3.2.0: {}
 
@@ -6229,7 +5833,7 @@ snapshots:
 
   estree-util-attach-comments@3.0.0:
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
 
   estree-util-build-jsx@3.0.1:
     dependencies:
@@ -6242,7 +5846,7 @@ snapshots:
 
   estree-util-scope@1.0.0:
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
       devlop: 1.1.0
 
   estree-util-to-js@2.0.0:
@@ -6260,7 +5864,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
 
   etag@1.8.1: {}
 
@@ -6270,22 +5874,37 @@ snapshots:
 
   extend@3.0.2: {}
 
-  fast-content-type-parse@3.0.0: {}
-
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@3.1.0: {}
+  fast-string-truncated-width@3.0.3: {}
 
-  fast-xml-builder@1.0.0: {}
-
-  fast-xml-parser@5.4.2:
+  fast-string-width@3.0.2:
     dependencies:
-      fast-xml-builder: 1.0.0
-      strnum: 2.2.0
+      fast-string-truncated-width: 3.0.3
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fast-uri@3.1.2: {}
+
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
+
+  fast-xml-builder@1.2.0:
+    dependencies:
+      path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
+
+  fast-xml-parser@5.9.2:
+    dependencies:
+      "@nodable/entities": 2.2.0
+      fast-xml-builder: 1.2.0
+      is-unsafe: 1.0.1
+      path-expression-matcher: 1.5.0
+      strnum: 2.4.0
+      xml-naming: 0.1.0
+
+  fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
-      picomatch: 4.0.3
+      picomatch: 4.0.4
 
   file-uri-to-path@1.0.0: {}
 
@@ -6295,9 +5914,9 @@ snapshots:
 
   fontace@0.4.1:
     dependencies:
-      fontkitten: 1.0.2
+      fontkitten: 1.0.3
 
-  fontkitten@1.0.2:
+  fontkitten@1.0.3:
     dependencies:
       tiny-inflate: 1.0.3
 
@@ -6310,22 +5929,24 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
-  get-east-asian-width@1.5.0: {}
+  get-tsconfig@5.0.0-beta.4:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   github-from-package@0.0.0: {}
 
   github-slugger@2.0.0: {}
 
-  h3@1.15.5:
+  h3@1.15.11:
     dependencies:
-      cookie-es: 1.2.2
+      cookie-es: 1.2.3
       crossws: 0.3.5
-      defu: 6.1.4
+      defu: 6.1.7
       destr: 2.0.5
       iron-webcrypto: 1.2.1
       node-mock-http: 1.0.4
       radix3: 1.1.2
-      ufo: 1.6.3
+      ufo: 1.6.4
       uncrypto: 0.1.3
 
   hast-util-from-dom@5.0.1:
@@ -6373,7 +5994,7 @@ snapshots:
     dependencies:
       "@types/hast": 3.0.4
       "@types/unist": 3.0.3
-      "@ungap/structured-clone": 1.3.0
+      "@ungap/structured-clone": 1.3.1
       hast-util-from-parse5: 8.0.3
       hast-util-to-parse5: 8.0.1
       html-void-elements: 3.0.0
@@ -6387,7 +6008,7 @@ snapshots:
 
   hast-util-to-estree@3.1.3:
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
       "@types/estree-jsx": 1.0.5
       "@types/hast": 3.0.4
       comma-separated-tokens: 2.0.3
@@ -6398,7 +6019,7 @@ snapshots:
       mdast-util-mdx-expression: 2.0.1
       mdast-util-mdx-jsx: 3.2.0
       mdast-util-mdxjs-esm: 2.0.1
-      property-information: 7.1.0
+      property-information: 7.2.0
       space-separated-tokens: 2.0.2
       style-to-js: 1.1.21
       unist-util-position: 5.0.0
@@ -6415,14 +6036,14 @@ snapshots:
       hast-util-whitespace: 3.0.0
       html-void-elements: 3.0.0
       mdast-util-to-hast: 13.2.1
-      property-information: 7.1.0
+      property-information: 7.2.0
       space-separated-tokens: 2.0.2
       stringify-entities: 4.0.4
       zwitch: 2.0.4
 
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
       "@types/hast": 3.0.4
       "@types/unist": 3.0.3
       comma-separated-tokens: 2.0.3
@@ -6432,7 +6053,7 @@ snapshots:
       mdast-util-mdx-expression: 2.0.1
       mdast-util-mdx-jsx: 3.2.0
       mdast-util-mdxjs-esm: 2.0.1
-      property-information: 7.1.0
+      property-information: 7.2.0
       space-separated-tokens: 2.0.2
       style-to-js: 1.1.21
       unist-util-position: 5.0.0
@@ -6445,7 +6066,7 @@ snapshots:
       "@types/hast": 3.0.4
       comma-separated-tokens: 2.0.3
       devlop: 1.1.0
-      property-information: 7.1.0
+      property-information: 7.2.0
       space-separated-tokens: 2.0.2
       web-namespaces: 2.0.1
       zwitch: 2.0.4
@@ -6487,8 +6108,6 @@ snapshots:
 
   ieee754@1.2.1: {}
 
-  import-meta-resolve@4.2.0: {}
-
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
@@ -6508,6 +6127,8 @@ snapshots:
 
   is-docker@3.0.0: {}
 
+  is-docker@4.0.0: {}
+
   is-fullwidth-code-point@3.0.0: {}
 
   is-hexadecimal@2.0.1: {}
@@ -6518,19 +6139,21 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-unsafe@1.0.1: {}
+
   is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
 
   iso-datestring-validator@2.2.2: {}
 
-  js-yaml@4.1.1:
+  js-yaml@4.2.0:
     dependencies:
       argparse: 2.0.1
 
   json-schema-traverse@1.0.0: {}
 
-  json-with-bigint@3.5.7: {}
+  json-with-bigint@3.5.8: {}
 
   jsonc-parser@2.3.1: {}
 
@@ -6540,15 +6163,11 @@ snapshots:
     dependencies:
       commander: 8.3.0
 
-  kleur@3.0.3: {}
-
   kleur@4.1.5: {}
-
-  lodash@4.17.21: {}
 
   longest-streak@3.1.0: {}
 
-  lru-cache@11.2.6: {}
+  lru-cache@11.5.1: {}
 
   lucide-static@0.562.0: {}
 
@@ -6556,21 +6175,21 @@ snapshots:
     dependencies:
       "@jridgewell/sourcemap-codec": 1.5.5
 
-  magicast@0.5.2:
+  magicast@0.5.3:
     dependencies:
-      "@babel/parser": 7.29.0
-      "@babel/types": 7.29.0
+      "@babel/parser": 7.29.7
+      "@babel/types": 7.29.7
       source-map-js: 1.2.1
 
   markdown-extensions@2.0.0: {}
 
   markdown-table@3.0.4: {}
 
-  marked-highlight@2.2.3(marked@17.0.4):
+  marked-highlight@2.2.4(marked@18.0.5):
     dependencies:
-      marked: 17.0.4
+      marked: 18.0.5
 
-  marked@17.0.4: {}
+  marked@18.0.5: {}
 
   mdast-util-definitions@6.0.0:
     dependencies:
@@ -6743,7 +6362,7 @@ snapshots:
     dependencies:
       "@types/hast": 3.0.4
       "@types/mdast": 4.0.4
-      "@ungap/structured-clone": 1.3.0
+      "@ungap/structured-clone": 1.3.1
       devlop: 1.1.0
       micromark-util-sanitize-uri: 2.0.1
       trim-lines: 3.0.1
@@ -6769,7 +6388,7 @@ snapshots:
 
   mdn-data@2.0.28: {}
 
-  mdn-data@2.12.2: {}
+  mdn-data@2.27.1: {}
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -7079,9 +6698,9 @@ snapshots:
 
   muggle-string@0.4.1: {}
 
-  multiformats@9.9.0: {}
+  multiformats@13.4.2: {}
 
-  nanoid@3.3.11: {}
+  nanoid@3.3.12: {}
 
   napi-build-utils@2.0.0: {}
 
@@ -7105,6 +6724,8 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
+  obug@2.1.3: {}
+
   octokit@5.0.5:
     dependencies:
       "@octokit/app": 16.1.2
@@ -7123,7 +6744,7 @@ snapshots:
     dependencies:
       destr: 2.0.5
       node-fetch-native: 1.6.7
-      ufo: 1.6.3
+      ufo: 1.6.4
 
   ohash@2.0.11: {}
 
@@ -7135,24 +6756,24 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
-  oniguruma-parser@0.12.1: {}
+  oniguruma-parser@0.12.2: {}
 
-  oniguruma-to-es@4.3.4:
+  oniguruma-to-es@4.3.6:
     dependencies:
-      oniguruma-parser: 0.12.1
+      oniguruma-parser: 0.12.2
       regex: 6.1.0
       regex-recursion: 6.0.2
 
-  p-limit@6.2.0:
+  p-limit@7.3.0:
     dependencies:
       yocto-queue: 1.2.2
 
-  p-queue@8.1.1:
+  p-queue@9.3.0:
     dependencies:
       eventemitter3: 5.0.4
-      p-timeout: 6.1.4
+      p-timeout: 7.0.1
 
-  p-timeout@6.1.4: {}
+  p-timeout@7.0.1: {}
 
   package-manager-detector@1.6.0: {}
 
@@ -7181,17 +6802,19 @@ snapshots:
 
   path-browserify@1.0.1: {}
 
+  path-expression-matcher@1.5.0: {}
+
   piccolore@0.1.3: {}
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.1: {}
+  picomatch@2.3.2: {}
 
-  picomatch@4.0.3: {}
+  picomatch@4.0.4: {}
 
-  postcss@8.5.8:
+  postcss@8.5.15:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -7213,19 +6836,16 @@ snapshots:
   prettier-plugin-astro@0.14.1:
     dependencies:
       "@astrojs/compiler": 2.13.1
-      prettier: 3.8.1
+      prettier: 3.8.4
       sass-formatter: 0.7.9
 
-  prettier@3.8.1: {}
+  prettier@3.8.4: {}
 
   prismjs@1.30.0: {}
 
-  prompts@2.4.2:
-    dependencies:
-      kleur: 3.0.3
-      sisteransi: 1.0.5
-
   property-information@7.1.0: {}
+
+  property-information@7.2.0: {}
 
   pump@3.0.4:
     dependencies:
@@ -7257,14 +6877,14 @@ snapshots:
 
   recma-build-jsx@1.0.0:
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
       estree-util-build-jsx: 3.0.1
       vfile: 6.0.3
 
-  recma-jsx@1.0.1(acorn@8.16.0):
+  recma-jsx@1.0.1(acorn@8.17.0):
     dependencies:
-      acorn: 8.16.0
-      acorn-jsx: 5.3.2(acorn@8.16.0)
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
       estree-util-to-js: 2.0.0
       recma-parse: 1.0.0
       recma-stringify: 1.0.0
@@ -7272,14 +6892,14 @@ snapshots:
 
   recma-parse@1.0.0:
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
       esast-util-from-js: 2.0.1
       unified: 11.0.5
       vfile: 6.0.3
 
   recma-stringify@1.0.0:
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
       estree-util-to-js: 2.0.0
       unified: 11.0.5
       vfile: 6.0.3
@@ -7318,7 +6938,7 @@ snapshots:
 
   rehype-recma@1.0.0:
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
       "@types/hast": 3.0.4
       hast-util-to-estree: 3.1.3
     transitivePeerDependencies:
@@ -7411,6 +7031,8 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  resolve-pkg-maps@1.0.0: {}
+
   retext-latin@4.0.0:
     dependencies:
       "@types/nlcst": 2.0.3
@@ -7436,35 +7058,35 @@ snapshots:
       retext-stringify: 4.0.0
       unified: 11.0.5
 
-  rollup@4.59.0:
+  rollup@4.62.0:
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
     optionalDependencies:
-      "@rollup/rollup-android-arm-eabi": 4.59.0
-      "@rollup/rollup-android-arm64": 4.59.0
-      "@rollup/rollup-darwin-arm64": 4.59.0
-      "@rollup/rollup-darwin-x64": 4.59.0
-      "@rollup/rollup-freebsd-arm64": 4.59.0
-      "@rollup/rollup-freebsd-x64": 4.59.0
-      "@rollup/rollup-linux-arm-gnueabihf": 4.59.0
-      "@rollup/rollup-linux-arm-musleabihf": 4.59.0
-      "@rollup/rollup-linux-arm64-gnu": 4.59.0
-      "@rollup/rollup-linux-arm64-musl": 4.59.0
-      "@rollup/rollup-linux-loong64-gnu": 4.59.0
-      "@rollup/rollup-linux-loong64-musl": 4.59.0
-      "@rollup/rollup-linux-ppc64-gnu": 4.59.0
-      "@rollup/rollup-linux-ppc64-musl": 4.59.0
-      "@rollup/rollup-linux-riscv64-gnu": 4.59.0
-      "@rollup/rollup-linux-riscv64-musl": 4.59.0
-      "@rollup/rollup-linux-s390x-gnu": 4.59.0
-      "@rollup/rollup-linux-x64-gnu": 4.59.0
-      "@rollup/rollup-linux-x64-musl": 4.59.0
-      "@rollup/rollup-openbsd-x64": 4.59.0
-      "@rollup/rollup-openharmony-arm64": 4.59.0
-      "@rollup/rollup-win32-arm64-msvc": 4.59.0
-      "@rollup/rollup-win32-ia32-msvc": 4.59.0
-      "@rollup/rollup-win32-x64-gnu": 4.59.0
-      "@rollup/rollup-win32-x64-msvc": 4.59.0
+      "@rollup/rollup-android-arm-eabi": 4.62.0
+      "@rollup/rollup-android-arm64": 4.62.0
+      "@rollup/rollup-darwin-arm64": 4.62.0
+      "@rollup/rollup-darwin-x64": 4.62.0
+      "@rollup/rollup-freebsd-arm64": 4.62.0
+      "@rollup/rollup-freebsd-x64": 4.62.0
+      "@rollup/rollup-linux-arm-gnueabihf": 4.62.0
+      "@rollup/rollup-linux-arm-musleabihf": 4.62.0
+      "@rollup/rollup-linux-arm64-gnu": 4.62.0
+      "@rollup/rollup-linux-arm64-musl": 4.62.0
+      "@rollup/rollup-linux-loong64-gnu": 4.62.0
+      "@rollup/rollup-linux-loong64-musl": 4.62.0
+      "@rollup/rollup-linux-ppc64-gnu": 4.62.0
+      "@rollup/rollup-linux-ppc64-musl": 4.62.0
+      "@rollup/rollup-linux-riscv64-gnu": 4.62.0
+      "@rollup/rollup-linux-riscv64-musl": 4.62.0
+      "@rollup/rollup-linux-s390x-gnu": 4.62.0
+      "@rollup/rollup-linux-x64-gnu": 4.62.0
+      "@rollup/rollup-linux-x64-musl": 4.62.0
+      "@rollup/rollup-openbsd-x64": 4.62.0
+      "@rollup/rollup-openharmony-arm64": 4.62.0
+      "@rollup/rollup-win32-arm64-msvc": 4.62.0
+      "@rollup/rollup-win32-ia32-msvc": 4.62.0
+      "@rollup/rollup-win32-x64-gnu": 4.62.0
+      "@rollup/rollup-win32-x64-msvc": 4.62.0
       fsevents: 2.3.3
 
   s.color@0.0.15: {}
@@ -7475,9 +7097,11 @@ snapshots:
     dependencies:
       suf-log: 2.5.3
 
-  sax@1.5.0: {}
+  sax@1.6.0: {}
 
   semver@7.7.4: {}
+
+  semver@7.8.4: {}
 
   send@1.2.1:
     dependencies:
@@ -7503,7 +7127,7 @@ snapshots:
     dependencies:
       "@img/colour": 1.1.0
       detect-libc: 2.1.2
-      semver: 7.7.4
+      semver: 7.8.4
     optionalDependencies:
       "@img/sharp-darwin-arm64": 0.34.5
       "@img/sharp-darwin-x64": 0.34.5
@@ -7531,14 +7155,14 @@ snapshots:
       "@img/sharp-win32-x64": 0.34.5
     optional: true
 
-  shiki@3.23.0:
+  shiki@4.2.0:
     dependencies:
-      "@shikijs/core": 3.23.0
-      "@shikijs/engine-javascript": 3.23.0
-      "@shikijs/engine-oniguruma": 3.23.0
-      "@shikijs/langs": 3.23.0
-      "@shikijs/themes": 3.23.0
-      "@shikijs/types": 3.23.0
+      "@shikijs/core": 4.2.0
+      "@shikijs/engine-javascript": 4.2.0
+      "@shikijs/engine-oniguruma": 4.2.0
+      "@shikijs/langs": 4.2.0
+      "@shikijs/themes": 4.2.0
+      "@shikijs/types": 4.2.0
       "@shikijs/vscode-textmate": 10.0.2
       "@types/hast": 3.0.4
 
@@ -7552,14 +7176,14 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
-  sitemap@8.0.3:
+  sitemap@9.0.1:
     dependencies:
-      "@types/node": 17.0.45
+      "@types/node": 24.13.2
       "@types/sax": 1.2.7
       arg: 5.0.2
-      sax: 1.5.0
+      sax: 1.6.0
 
-  smol-toml@1.6.0: {}
+  smol-toml@1.6.1: {}
 
   source-map-js@1.2.1: {}
 
@@ -7577,12 +7201,6 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
-  string-width@7.2.0:
-    dependencies:
-      emoji-regex: 10.6.0
-      get-east-asian-width: 1.5.0
-      strip-ansi: 7.2.0
-
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -7596,13 +7214,11 @@ snapshots:
     dependencies:
       ansi-regex: 5.0.1
 
-  strip-ansi@7.2.0:
-    dependencies:
-      ansi-regex: 6.2.2
-
   strip-json-comments@2.0.1: {}
 
-  strnum@2.2.0: {}
+  strnum@2.4.0:
+    dependencies:
+      anynum: 1.0.0
 
   style-to-js@1.1.21:
     dependencies:
@@ -7616,15 +7232,15 @@ snapshots:
     dependencies:
       s.color: 0.0.15
 
-  svgo@4.0.0:
+  svgo@4.0.1:
     dependencies:
       commander: 11.1.0
       css-select: 5.2.2
-      css-tree: 3.1.0
+      css-tree: 3.2.1
       css-what: 6.2.2
       csso: 5.0.5
       picocolors: 1.1.1
-      sax: 1.5.0
+      sax: 1.6.0
 
   tar-fs@2.1.4:
     dependencies:
@@ -7641,7 +7257,7 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  tar@7.5.11:
+  tar@7.5.16:
     dependencies:
       "@isaacs/fs-minipass": 4.0.1
       chownr: 3.0.0
@@ -7651,16 +7267,18 @@ snapshots:
 
   tiny-inflate@1.0.3: {}
 
-  tinyexec@1.0.2: {}
+  tinyclip@0.1.14: {}
 
-  tinyglobby@0.2.15:
+  tinyexec@1.2.4: {}
+
+  tinyglobby@0.2.17:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tlds@1.261.0: {}
 
-  toad-cache@3.7.0: {}
+  toad-cache@3.7.1: {}
 
   toidentifier@1.0.1: {}
 
@@ -7668,35 +7286,31 @@ snapshots:
 
   trough@2.2.0: {}
 
-  tsconfck@3.1.6(typescript@5.9.3):
-    optionalDependencies:
-      typescript: 5.9.3
-
   tslib@2.8.1: {}
 
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
 
-  type-fest@4.41.0: {}
-
   typesafe-path@0.2.2: {}
 
   typescript-auto-import-cache@0.3.6:
     dependencies:
-      semver: 7.7.4
+      semver: 7.8.4
 
   typescript@5.9.3: {}
 
-  ufo@1.6.3: {}
+  ufo@1.6.4: {}
 
-  uint8arrays@3.0.0:
+  uint8arrays@5.1.1:
     dependencies:
-      multiformats: 9.9.0
+      multiformats: 13.4.2
 
   ultrahtml@1.6.0: {}
 
   uncrypto@0.1.3: {}
+
+  undici-types@7.18.2: {}
 
   unicode-segmenter@0.14.5: {}
 
@@ -7712,7 +7326,7 @@ snapshots:
 
   unifont@0.7.4:
     dependencies:
-      css-tree: 3.1.0
+      css-tree: 3.2.1
       ofetch: 1.5.1
       ohash: 2.0.11
 
@@ -7766,16 +7380,16 @@ snapshots:
 
   universal-user-agent@7.0.3: {}
 
-  unstorage@1.17.4:
+  unstorage@1.17.5:
     dependencies:
       anymatch: 3.1.3
       chokidar: 5.0.0
       destr: 2.0.5
-      h3: 1.15.5
-      lru-cache: 11.2.6
+      h3: 1.15.11
+      lru-cache: 11.5.1
       node-fetch-native: 1.6.7
       ofetch: 1.5.1
-      ufo: 1.6.3
+      ufo: 1.6.4
 
   util-deprecate@1.0.2: {}
 
@@ -7798,23 +7412,24 @@ snapshots:
       "@types/unist": 3.0.3
       vfile-message: 4.0.3
 
-  vite@6.4.1(yaml@2.8.2):
+  vite@7.3.5(@types/node@24.13.2)(yaml@2.9.0):
     dependencies:
-      esbuild: 0.25.12
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.8
-      rollup: 4.59.0
-      tinyglobby: 0.2.15
+      esbuild: 0.28.1
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rollup: 4.62.0
+      tinyglobby: 0.2.17
     optionalDependencies:
+      "@types/node": 24.13.2
       fsevents: 2.3.3
-      yaml: 2.8.2
+      yaml: 2.9.0
 
-  vitefu@1.1.2(vite@6.4.1(yaml@2.8.2)):
+  vitefu@1.1.3(vite@7.3.5(@types/node@24.13.2)(yaml@2.9.0)):
     optionalDependencies:
-      vite: 6.4.1(yaml@2.8.2)
+      vite: 7.3.5(@types/node@24.13.2)(yaml@2.9.0)
 
-  volar-service-css@0.0.68(@volar/language-service@2.4.28):
+  volar-service-css@0.0.70(@volar/language-service@2.4.28):
     dependencies:
       vscode-css-languageservice: 6.3.10
       vscode-languageserver-textdocument: 1.0.12
@@ -7822,7 +7437,7 @@ snapshots:
     optionalDependencies:
       "@volar/language-service": 2.4.28
 
-  volar-service-emmet@0.0.68(@volar/language-service@2.4.28):
+  volar-service-emmet@0.0.70(@volar/language-service@2.4.28):
     dependencies:
       "@emmetio/css-parser": 0.4.1
       "@emmetio/html-matcher": 1.3.0
@@ -7831,7 +7446,7 @@ snapshots:
     optionalDependencies:
       "@volar/language-service": 2.4.28
 
-  volar-service-html@0.0.68(@volar/language-service@2.4.28):
+  volar-service-html@0.0.70(@volar/language-service@2.4.28):
     dependencies:
       vscode-html-languageservice: 5.6.2
       vscode-languageserver-textdocument: 1.0.12
@@ -7839,23 +7454,23 @@ snapshots:
     optionalDependencies:
       "@volar/language-service": 2.4.28
 
-  volar-service-prettier@0.0.68(@volar/language-service@2.4.28)(prettier@3.8.1):
+  volar-service-prettier@0.0.70(@volar/language-service@2.4.28)(prettier@3.8.4):
     dependencies:
       vscode-uri: 3.1.0
     optionalDependencies:
       "@volar/language-service": 2.4.28
-      prettier: 3.8.1
+      prettier: 3.8.4
 
-  volar-service-typescript-twoslash-queries@0.0.68(@volar/language-service@2.4.28):
+  volar-service-typescript-twoslash-queries@0.0.70(@volar/language-service@2.4.28):
     dependencies:
       vscode-uri: 3.1.0
     optionalDependencies:
       "@volar/language-service": 2.4.28
 
-  volar-service-typescript@0.0.68(@volar/language-service@2.4.28):
+  volar-service-typescript@0.0.70(@volar/language-service@2.4.28):
     dependencies:
       path-browserify: 1.0.1
-      semver: 7.7.4
+      semver: 7.8.4
       typescript-auto-import-cache: 0.3.6
       vscode-languageserver-textdocument: 1.0.12
       vscode-nls: 5.2.0
@@ -7863,10 +7478,10 @@ snapshots:
     optionalDependencies:
       "@volar/language-service": 2.4.28
 
-  volar-service-yaml@0.0.68(@volar/language-service@2.4.28):
+  volar-service-yaml@0.0.71(@volar/language-service@2.4.28):
     dependencies:
       vscode-uri: 3.1.0
-      yaml-language-server: 1.19.2
+      yaml-language-server: 1.23.0
     optionalDependencies:
       "@volar/language-service": 2.4.28
 
@@ -7881,27 +7496,36 @@ snapshots:
     dependencies:
       "@vscode/l10n": 0.0.18
       vscode-languageserver-textdocument: 1.0.12
-      vscode-languageserver-types: 3.17.5
+      vscode-languageserver-types: 3.18.0
       vscode-uri: 3.1.0
 
   vscode-json-languageservice@4.1.8:
     dependencies:
       jsonc-parser: 3.3.1
       vscode-languageserver-textdocument: 1.0.12
-      vscode-languageserver-types: 3.17.5
+      vscode-languageserver-types: 3.18.0
       vscode-nls: 5.2.0
       vscode-uri: 3.1.0
 
   vscode-jsonrpc@8.2.0: {}
+
+  vscode-jsonrpc@9.0.0: {}
 
   vscode-languageserver-protocol@3.17.5:
     dependencies:
       vscode-jsonrpc: 8.2.0
       vscode-languageserver-types: 3.17.5
 
+  vscode-languageserver-protocol@3.18.0:
+    dependencies:
+      vscode-jsonrpc: 9.0.0
+      vscode-languageserver-types: 3.18.0
+
   vscode-languageserver-textdocument@1.0.12: {}
 
   vscode-languageserver-types@3.17.5: {}
+
+  vscode-languageserver-types@3.18.0: {}
 
   vscode-languageserver@9.0.1:
     dependencies:
@@ -7911,13 +7535,13 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
-  vue@3.5.30(typescript@5.9.3):
+  vue@3.5.38(typescript@5.9.3):
     dependencies:
-      "@vue/compiler-dom": 3.5.30
-      "@vue/compiler-sfc": 3.5.30
-      "@vue/runtime-dom": 3.5.30
-      "@vue/server-renderer": 3.5.30(vue@3.5.30(typescript@5.9.3))
-      "@vue/shared": 3.5.30
+      "@vue/compiler-dom": 3.5.38
+      "@vue/compiler-sfc": 3.5.38
+      "@vue/runtime-dom": 3.5.38
+      "@vue/server-renderer": 3.5.38(vue@3.5.38(typescript@5.9.3))
+      "@vue/shared": 3.5.38
     optionalDependencies:
       typescript: 5.9.3
 
@@ -7925,23 +7549,15 @@ snapshots:
 
   which-pm-runs@1.1.0: {}
 
-  widest-line@5.0.0:
-    dependencies:
-      string-width: 7.2.0
-
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-  wrap-ansi@9.0.2:
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 7.2.0
-      strip-ansi: 7.2.0
-
   wrappy@1.0.2: {}
+
+  xml-naming@0.1.0: {}
 
   xxhash-wasm@1.1.0: {}
 
@@ -7949,26 +7565,28 @@ snapshots:
 
   yallist@5.0.0: {}
 
-  yaml-language-server@1.19.2:
+  yaml-language-server@1.23.0:
     dependencies:
       "@vscode/l10n": 0.0.18
-      ajv: 8.18.0
-      ajv-draft-04: 1.0.0(ajv@8.18.0)
-      lodash: 4.17.21
-      prettier: 3.8.1
+      ajv: 8.20.0
+      ajv-draft-04: 1.0.0(ajv@8.20.0)
+      ajv-i18n: 4.2.0(ajv@8.20.0)
+      prettier: 3.8.4
       request-light: 0.5.8
       vscode-json-languageservice: 4.1.8
       vscode-languageserver: 9.0.1
       vscode-languageserver-textdocument: 1.0.12
-      vscode-languageserver-types: 3.17.5
+      vscode-languageserver-types: 3.18.0
       vscode-uri: 3.1.0
-      yaml: 2.7.1
+      yaml: 2.8.3
 
-  yaml@2.7.1: {}
+  yaml@2.8.3: {}
 
-  yaml@2.8.2: {}
+  yaml@2.9.0: {}
 
   yargs-parser@21.1.1: {}
+
+  yargs-parser@22.0.0: {}
 
   yargs@17.7.2:
     dependencies:
@@ -7982,21 +7600,8 @@ snapshots:
 
   yocto-queue@1.2.2: {}
 
-  yocto-spinner@0.2.3:
-    dependencies:
-      yoctocolors: 2.1.2
-
-  yoctocolors@2.1.2: {}
-
-  zod-to-json-schema@3.25.1(zod@3.25.76):
-    dependencies:
-      zod: 3.25.76
-
-  zod-to-ts@1.2.0(typescript@5.9.3)(zod@3.25.76):
-    dependencies:
-      typescript: 5.9.3
-      zod: 3.25.76
-
   zod@3.25.76: {}
+
+  zod@4.4.3: {}
 
   zwitch@2.0.4: {}

--- a/scripts/audit-assets.ts
+++ b/scripts/audit-assets.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { basename, dirname, join, relative } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -50,6 +50,10 @@ function getExtension(path: string) {
 }
 
 function collectFigureAssets() {
+  if (!existsSync(PUBLIC_FIGURES_DIR)) {
+    return [];
+  }
+
   return walk(PUBLIC_FIGURES_DIR, (path) =>
     IMAGE_EXTENSIONS.has(getExtension(path)),
   )

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -2,18 +2,16 @@ import { defineCollection } from "astro:content";
 import { glob } from "astro/loaders";
 import { z } from "astro/zod";
 
-const baseContentSchema = z
-  .object({
-    routeSlug: z.union([z.string(), z.number()]).optional(),
-    title: z.string().optional(),
-    description: z.string().optional(),
-    image: z.string().optional(),
-    createdAt: z.string().optional(),
-    updatedAt: z.string().optional(),
-    published: z.boolean().optional(),
-    type: z.string().optional(),
-  })
-  .passthrough();
+const baseContentSchema = z.looseObject({
+  routeSlug: z.union([z.string(), z.number()]).optional(),
+  title: z.string().optional(),
+  description: z.string().optional(),
+  image: z.string().optional(),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+  published: z.boolean().optional(),
+  type: z.string().optional(),
+});
 
 const projectSchema = baseContentSchema.extend({
   projectUrl: z.string().optional(),


### PR DESCRIPTION
## Summary

- Upgrade Astro, official integrations, Waline, tar, and related dependency baseline for issue #20.
- Remove unused `@ascorbic/feed-loader` after confirming it is not referenced and is not Astro 6-compatible.
- Add narrow `pnpm.overrides` for patched `esbuild` and `volar-service-yaml` transitive security paths.
- Migrate Astro markdown config to `markdown.processor: unified(...)`, update Zod schema to `z.looseObject()`, and make asset audit tolerate a missing `public/figures` directory.

Closes #20

## Verification

- [x] `pnpm check`
- [x] `pnpm build`
- [x] `pnpm format:check`
- [x] `pnpm run audit:content`
- [x] `pnpm run audit:assets`
- [x] `pnpm audit --registry=https://registry.npmjs.org --audit-level low`
- [x] Preview endpoint checks for `/rss.xml`, `/robots.txt`, and `/sitemap-index.xml`