### PR TITLE
fix(waline): 兼容公开服务端地址变量

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,6 +65,9 @@ jobs:
 
       - name: Build
         if: steps.cache.outputs.cache-hit != 'true'
+        env:
+          WALINE_SERVER_URL: ${{ secrets.WALINE_SERVER_URL || secrets.PUBLIC_WALINE_SERVER_URL || vars.WALINE_SERVER_URL || vars.PUBLIC_WALINE_SERVER_URL }}
+          PUBLIC_WALINE_SERVER_URL: ${{ secrets.PUBLIC_WALINE_SERVER_URL || secrets.WALINE_SERVER_URL || vars.PUBLIC_WALINE_SERVER_URL || vars.WALINE_SERVER_URL }}
         run: pnpm build
 
       - name: Sync Algolia index
@@ -98,7 +101,8 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           {
-            echo "WALINE_SERVER_URL=${{ secrets.PUBLIC_WALINE_SERVER_URL }}"
+            echo "WALINE_SERVER_URL=${{ secrets.WALINE_SERVER_URL || secrets.PUBLIC_WALINE_SERVER_URL || vars.WALINE_SERVER_URL || vars.PUBLIC_WALINE_SERVER_URL }}"
+            echo "PUBLIC_WALINE_SERVER_URL=${{ secrets.PUBLIC_WALINE_SERVER_URL || secrets.WALINE_SERVER_URL || vars.PUBLIC_WALINE_SERVER_URL || vars.WALINE_SERVER_URL }}"
             echo "CODETIME_TOKEN=${{ secrets.CODETIME_TOKEN }}"
           } | \
             ssh -i ~/.ssh/deploy_key -p ${{ env.SSH_PORT }} \

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -26,6 +26,11 @@ export default defineConfig({
         access: "secret",
         optional: true,
       }),
+      PUBLIC_WALINE_SERVER_URL: envField.string({
+        context: "server",
+        access: "public",
+        optional: true,
+      }),
       GITHUB_TOKEN: envField.string({
         context: "server",
         access: "secret",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Astro-star",
   "type": "module",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "packageManager": "pnpm@10.30.3",
   "scripts": {
     "predev": "node --experimental-strip-types scripts/generate-git-timestamps.ts",

--- a/src/components/content/WalineComments.astro
+++ b/src/components/content/WalineComments.astro
@@ -1,5 +1,6 @@
 ---
 import "@waline/client/waline.css";
+import { WALINE_SERVER_URL_ENV_LABEL } from "../../utils/waline-server-url";
 
 interface Props {
   articleRoutePath?: string;
@@ -45,7 +46,7 @@ const articleRoutePath = normalizeWalinePath(
     ) : (
       <p class="article-comments-empty">
         Comments are temporarily unavailable because{" "}
-        <code>WALINE_SERVER_URL</code> is not configured.
+        <code>{WALINE_SERVER_URL_ENV_LABEL}</code> is not configured.
       </p>
     )
   }

--- a/src/pages/[section]/[slug].astro
+++ b/src/pages/[section]/[slug].astro
@@ -1,7 +1,6 @@
 ---
 import { getCollection, render } from "astro:content";
 import ArticleDetailPage from "../../components/content/ArticleDetailPage.astro";
-import { WALINE_SERVER_URL } from "astro:env/server";
 import { site } from "../../config/site";
 import { getAdjacentArticles } from "../../utils/adjacent-articles";
 import { resolveContentDates } from "../../utils/content-dates";
@@ -15,6 +14,7 @@ import {
 import { resolveContentTitle } from "../../utils/content-title";
 import { isPublishedContentEntry } from "../../utils/content-visibility";
 import { getGitTimestamps } from "../../utils/git-timestamps";
+import { getWalineServerURL } from "../../utils/waline-server-url";
 
 const validSections = ["blog", "note", "project"] as const;
 type SectionKey = (typeof validSections)[number];
@@ -84,7 +84,7 @@ const docUrl =
     ? (articleEntry.data as { docUrl?: string }).docUrl?.trim() || ""
     : "";
 const author = site.profile.name;
-const walineServerURL = WALINE_SERVER_URL?.trim() || "";
+const walineServerURL = getWalineServerURL();
 const articleRoutePath = `/${section}/${slug}/`;
 const contentPath =
   articleEntry.filePath ?? `src/content/${section}/${articleEntry.id}.mdx`;

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,9 +1,9 @@
 ---
 import { getCollection, render } from "astro:content";
-import { WALINE_SERVER_URL } from "astro:env/server";
 import DocumentDetailPage from "../components/content/DocumentDetailPage.astro";
 import WalineComments from "../components/content/WalineComments.astro";
 import { site } from "../config/site";
+import { getWalineServerURL } from "../utils/waline-server-url";
 
 export const prerender = true;
 
@@ -25,7 +25,7 @@ const contentTitle = pageEntry.data.heading || title;
 const contentTitleId = pageEntry.id;
 const pageRoutePath = "/about/";
 const canonicalUrl = new URL(pageRoutePath, site.site.url).toString();
-const walineServerURL = WALINE_SERVER_URL?.trim() || "";
+const walineServerURL = getWalineServerURL();
 const tocHeadings = [
   {
     depth: 1 as const,

--- a/src/pages/api/waline-config.json.ts
+++ b/src/pages/api/waline-config.json.ts
@@ -1,10 +1,10 @@
 import type { APIRoute } from "astro";
-import { WALINE_SERVER_URL } from "astro:env/server";
+import { getWalineServerURL } from "../../utils/waline-server-url";
 
 export const GET: APIRoute = () => {
   return new Response(
     JSON.stringify({
-      serverURL: WALINE_SERVER_URL?.trim() || "",
+      serverURL: getWalineServerURL(),
     }),
     {
       headers: {

--- a/src/pages/links.astro
+++ b/src/pages/links.astro
@@ -1,9 +1,9 @@
 ---
 import { getCollection, render } from "astro:content";
-import { WALINE_SERVER_URL } from "astro:env/server";
 import DocumentDetailPage from "../components/content/DocumentDetailPage.astro";
 import WalineComments from "../components/content/WalineComments.astro";
 import { site } from "../config/site";
+import { getWalineServerURL } from "../utils/waline-server-url";
 
 export const prerender = true;
 
@@ -25,7 +25,7 @@ const contentTitle = pageEntry.data.heading || title;
 const contentTitleId = pageEntry.id;
 const pageRoutePath = "/links/";
 const canonicalUrl = new URL(pageRoutePath, site.site.url).toString();
-const walineServerURL = WALINE_SERVER_URL?.trim() || "";
+const walineServerURL = getWalineServerURL();
 const tocHeadings = [
   {
     depth: 1 as const,

--- a/src/scripts/home-shell-waline.ts
+++ b/src/scripts/home-shell-waline.ts
@@ -533,7 +533,9 @@ async function hydrateWalineComments(runId: number) {
     const lang = WALINE_COMMENTS_LANG;
 
     if (!serverURL) {
-      console.warn("[Waline] WALINE_SERVER_URL is not configured.");
+      console.warn(
+        "[Waline] WALINE_SERVER_URL or PUBLIC_WALINE_SERVER_URL is not configured.",
+      );
       return;
     }
 

--- a/src/utils/waline-server-url.ts
+++ b/src/utils/waline-server-url.ts
@@ -1,0 +1,8 @@
+import { PUBLIC_WALINE_SERVER_URL, WALINE_SERVER_URL } from "astro:env/server";
+
+export const WALINE_SERVER_URL_ENV_LABEL =
+  "WALINE_SERVER_URL or PUBLIC_WALINE_SERVER_URL";
+
+export function getWalineServerURL() {
+  return WALINE_SERVER_URL?.trim() || PUBLIC_WALINE_SERVER_URL?.trim() || "";
+}


### PR DESCRIPTION
## Summary

- Support both `WALINE_SERVER_URL` and `PUBLIC_WALINE_SERVER_URL` for Waline server configuration.
- Centralize Waline server URL resolution so prerendered pages and `/api/waline-config.json` use the same fallback behavior.
- Inject both aliases during GitHub Actions build/deploy so prerendered comment blocks work when only `PUBLIC_WALINE_SERVER_URL` is configured.
- Update the empty-state copy and client warning to mention both supported names.

## Verification

- [x] `pnpm check`
- [x] `pnpm build`
- [x] `pnpm format:check`
- [x] `git diff --check`
- [x] `PUBLIC_WALINE_SERVER_URL=https://waline.example.com pnpm build`
- [x] Confirmed generated `about`, `links`, and article HTML include `data-waline-server-url="https://waline.example.com"` when only `PUBLIC_WALINE_SERVER_URL` is set.